### PR TITLE
Add multi-schedule support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ uvicorn app.main:app --reload
 
 Open your browser at `http://localhost:8000` to manage the schedule.
 
-Bell times are stored in `schedule.json`. The server polls this file every 30 seconds and triggers the configured devices.
+Bell schedules are stored in `schedule.json`. Multiple schedules can be created and the active one is chosen from the web interface. The server polls this file every 30 seconds and triggers the configured devices for the active schedule.
 
 Device IPs are stored in `devices.json` and can be managed from the admin page at `http://localhost:8000/admin`.

--- a/schedule.json
+++ b/schedule.json
@@ -1,1 +1,1 @@
-[]
+{"active": "Default", "schedules": {"Default": []}}

--- a/static/index.html
+++ b/static/index.html
@@ -12,6 +12,13 @@
 <body>
   <h1>Bell Schedule</h1>
   <p><a href="/admin">Configure Devices</a></p>
+  <div>
+    <label>Active schedule:
+      <select id="schedule-select"></select>
+    </label>
+    <input type="text" id="new-schedule" placeholder="New schedule">
+    <button id="add-schedule">Add</button>
+  </div>
   <form id="add-form">
     <label>Date/time: <input type="datetime-local" id="time" required></label>
     <label>Sound file: <input type="text" id="sound" placeholder="bell.mp3" required></label>
@@ -43,6 +50,38 @@ async function loadSchedule() {
   });
 }
 
+async function loadScheduleList() {
+  const res = await fetch('/api/schedules');
+  const data = await res.json();
+  const select = document.getElementById('schedule-select');
+  select.innerHTML = '';
+  data.schedules.forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    if (name === data.active) opt.selected = true;
+    select.appendChild(opt);
+  });
+}
+
+document.getElementById('schedule-select').onchange = async (e) => {
+  await fetch('/api/schedules/activate/' + encodeURIComponent(e.target.value), { method: 'POST' });
+  loadSchedule();
+};
+
+document.getElementById('add-schedule').onclick = async () => {
+  const name = document.getElementById('new-schedule').value.trim();
+  if (!name) return;
+  await fetch('/api/schedules', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name })
+  });
+  document.getElementById('new-schedule').value = '';
+  loadScheduleList();
+  loadSchedule();
+};
+
 document.getElementById('add-form').onsubmit = async (e) => {
   e.preventDefault();
   const time = document.getElementById('time').value;
@@ -56,6 +95,7 @@ document.getElementById('add-form').onsubmit = async (e) => {
   loadSchedule();
 };
 
+loadScheduleList();
 loadSchedule();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- support multiple schedules in `schedule.json`
- expose API endpoints to manage schedules and set the active one
- update web UI with a dropdown to choose or add schedules
- document new behaviour in README

## Testing
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6850d3aad8448321972e95e590caa8c4