### PR TITLE
Add audio upload management

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ Open your browser at `http://localhost:8000` to manage the schedule.
 Bell schedules are stored in `schedule.json`. Multiple schedules can be created and the active one is chosen from the web interface. The server polls this file every 30 seconds and triggers the configured devices for the active schedule.
 
 Device IPs are stored in `devices.json` and can be managed from the admin page at `http://localhost:8000/admin`.
+
+Audio files used for bells can be uploaded from the admin page as well. Uploaded
+files are stored in the `audio/` directory and are selectable when creating
+schedule entries.

--- a/static/admin.html
+++ b/static/admin.html
@@ -19,6 +19,13 @@
     <thead><tr><th>IP</th><th>Actions</th></tr></thead>
     <tbody></tbody>
   </table>
+
+  <h2>Audio Files</h2>
+  <form id="upload-form">
+    <input type="file" id="audio-file" accept="audio/*" required>
+    <button type="submit">Upload</button>
+  </form>
+  <ul id="audio-list"></ul>
   <script>
   async function loadDevices() {
     const res = await fetch('/api/devices');
@@ -54,6 +61,30 @@
   };
 
   loadDevices();
+
+  async function loadAudio() {
+    const res = await fetch('/api/audio');
+    const data = await res.json();
+    const list = document.getElementById('audio-list');
+    list.innerHTML = '';
+    data.forEach(name => {
+      const li = document.createElement('li');
+      li.textContent = name;
+      list.appendChild(li);
+    });
+  }
+
+  document.getElementById('upload-form').onsubmit = async (e) => {
+    e.preventDefault();
+    const fileInput = document.getElementById('audio-file');
+    const formData = new FormData();
+    formData.append('file', fileInput.files[0]);
+    await fetch('/api/audio', { method: 'POST', body: formData });
+    fileInput.value = '';
+    loadAudio();
+  };
+
+  loadAudio();
   </script>
 </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -21,7 +21,7 @@
   </div>
   <form id="add-form">
     <label>Date/time: <input type="datetime-local" id="time" required></label>
-    <label>Sound file: <input type="text" id="sound" placeholder="bell.mp3" required></label>
+    <label>Sound file: <select id="sound"></select></label>
     <button type="submit">Add</button>
   </form>
   <table id="schedule">
@@ -64,6 +64,19 @@ async function loadScheduleList() {
   });
 }
 
+async function loadAudio() {
+  const res = await fetch('/api/audio');
+  const data = await res.json();
+  const select = document.getElementById('sound');
+  select.innerHTML = '';
+  data.forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    select.appendChild(opt);
+  });
+}
+
 document.getElementById('schedule-select').onchange = async (e) => {
   await fetch('/api/schedules/activate/' + encodeURIComponent(e.target.value), { method: 'POST' });
   loadSchedule();
@@ -96,6 +109,7 @@ document.getElementById('add-form').onsubmit = async (e) => {
 };
 
 loadScheduleList();
+loadAudio();
 loadSchedule();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- manage uploaded audio on the admin page
- allow selecting audio files on the schedule page
- provide API endpoints for uploading and listing audio files

## Testing
- `python3 -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6850d4f84938832192a45527f696a116