### PR TITLE
Add logo and improved navigation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,9 +15,11 @@ SCHEDULE_FILE = Path("schedule.json")
 DEVICES_FILE = Path("devices.json")
 AUDIO_DIR = Path("audio")
 AUDIO_DIR.mkdir(exist_ok=True)
+STATIC_DIR = Path("static")
 
 app = FastAPI()
 app.mount("/audio", StaticFiles(directory=AUDIO_DIR), name="audio")
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 class ScheduleEntry(BaseModel):
     time: datetime

--- a/static/admin.html
+++ b/static/admin.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <title>Device Configuration</title>
-  <style>
-    body { font-family: sans-serif; margin: 40px; }
-    table { border-collapse: collapse; width: 100%; margin-top: 20px; }
-    th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
-  </style>
+  <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
+  <header>
+    <img src="/static/logo.svg" alt="PiBells logo" class="logo" />
+    <a href="/">Back to Schedule</a>
+  </header>
   <h1>Barix Devices</h1>
   <form id="add-form">
     <label>Device IP: <input type="text" id="ip" placeholder="192.168.1.10" required></label>

--- a/static/index.html
+++ b/static/index.html
@@ -3,15 +3,14 @@
 <head>
   <meta charset="UTF-8" />
   <title>PiBells Schedule</title>
-  <style>
-    body { font-family: sans-serif; margin: 40px; }
-    table { border-collapse: collapse; width: 100%; margin-top: 20px; }
-    th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
-  </style>
+  <link rel="stylesheet" href="/static/style.css">
 </head>
 <body>
+  <header>
+    <img src="/static/logo.svg" alt="PiBells logo" class="logo" />
+    <a href="/admin">Settings</a>
+  </header>
   <h1>Bell Schedule</h1>
-  <p><a href="/admin">Configure Devices</a></p>
   <div>
     <label>Active schedule:
       <select id="schedule-select"></select>

--- a/static/logo.svg
+++ b/static/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="160" height="50" viewBox="0 0 160 50">
+  <rect width="160" height="50" rx="8" fill="#007acc" />
+  <text x="80" y="32" font-family="Arial, sans-serif" font-size="28" fill="white" text-anchor="middle">PiBells</text>
+</svg>

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,44 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 40px;
+  background: #f5f5f5;
+  color: #333;
+}
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 20px;
+}
+header img.logo {
+  height: 50px;
+}
+a {
+  color: #007acc;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+
+/* table styling */
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin-top: 20px;
+  background: white;
+}
+th, td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: left;
+}
+th {
+  background: #eaeaea;
+}
+button {
+  padding: 5px 10px;
+}
+form {
+  margin-top: 20px;
+}


### PR DESCRIPTION
## Summary
- mount `/static` for serving style and logo
- add shared stylesheet and logo image
- update index page with professional design and link to settings
- update admin page with logo and link back to schedule

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6850d73cece8832192cc6c639a9388e1