### PR TITLE
Add install script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,35 @@ schedule entries.
 
 ## Permanent Installation on a Raspberry Pi 4
 
-To run PiBells automatically at boot, create a systemd service on your Pi:
+PiBells can run automatically at boot using a systemd service. The easiest way
+to set this up is with the provided `install.sh` script. Run the following
+commands on your Pi:
+
+```bash
+git clone https://github.com/alinaric/PiBells.git
+cd PiBells
+sudo ./install.sh
+```
+
+The script installs required packages, clones/updates the repository for the
+`pi` user and creates a `pibells.service` file in `/etc/systemd/system`. The
+service is then enabled and started so PiBells launches automatically on boot.
+
+If you prefer to perform these steps manually, the commands executed by the
+script are shown below for reference.
 
 1. **Install dependencies** (FastAPI and Uvicorn) if they are not already present:
 
    ```bash
    sudo apt update
-   sudo apt install python3 python3-pip -y
+   sudo apt install python3 python3-pip git -y
    pip3 install fastapi uvicorn
    ```
 
 2. **Clone the repository** to the home directory of the `pi` user:
 
    ```bash
-   git clone https://github.com/your-org/PiBells.git ~/PiBells
+   git clone https://github.com/alinaric/PiBells.git ~/PiBells
    cd ~/PiBells
    ```
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# PiBells installation script
+# Run this script with sudo to install PiBells as a systemd service
+
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "This script must be run with sudo or as root" >&2
+  exit 1
+fi
+
+apt-get update
+apt-get install -y python3 python3-pip git
+
+pip3 install fastapi uvicorn
+
+TARGET_USER=${SUDO_USER:-pi}
+HOME_DIR=$(eval echo "~$TARGET_USER")
+INSTALL_DIR="$HOME_DIR/PiBells"
+
+if [ -d "$INSTALL_DIR" ]; then
+  echo "Updating existing PiBells repo in $INSTALL_DIR"
+  git -C "$INSTALL_DIR" pull
+else
+  echo "Cloning PiBells repo to $INSTALL_DIR"
+  git clone https://github.com/alinaric/PiBells.git "$INSTALL_DIR"
+fi
+
+SERVICE_FILE=/etc/systemd/system/pibells.service
+
+cat > "$SERVICE_FILE" <<SERVICE
+[Unit]
+Description=PiBells Server
+After=network.target
+
+[Service]
+User=$TARGET_USER
+WorkingDirectory=$INSTALL_DIR
+ExecStart=/usr/bin/env uvicorn app.main:app --host 0.0.0.0
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+systemctl daemon-reload
+systemctl enable pibells
+systemctl restart pibells
+
+echo "PiBells installation complete. Service is running."


### PR DESCRIPTION
## Summary
- add an install script for permanent installation
- document automated install method in README
- clone from the correct GitHub repository

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850dbb6cf208321b3ac8523b5320082