### PR TITLE
Add configurable quick play buttons

### DIFF
--- a/static/buttons.html
+++ b/static/buttons.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Button Configuration</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <header>
+    <img src="/static/logo.svg" alt="PiBells logo" class="logo" />
+    <a href="/">Back to Schedule</a>
+  </header>
+  <h1>Quick Buttons</h1>
+  <form id="add-form">
+    <label>Name: <input type="text" id="name" required></label>
+    <label>Sound: <select id="sound"></select></label>
+    <label>Color: <input type="color" id="color" value="#ff0000"></label>
+    <label>Icon: <input type="text" id="icon" placeholder="emoji or icon"></label>
+    <button type="submit">Add</button>
+  </form>
+  <table id="buttons">
+    <thead><tr><th>Name</th><th>Sound</th><th>Icon</th><th>Color</th><th>Actions</th></tr></thead>
+    <tbody></tbody>
+  </table>
+<script>
+async function loadAudio() {
+  const res = await fetch('/api/audio');
+  const data = await res.json();
+  const select = document.getElementById('sound');
+  if (!select) return;
+  select.innerHTML = '';
+  data.forEach(name => {
+    const opt = document.createElement('option');
+    opt.value = name;
+    opt.textContent = name;
+    select.appendChild(opt);
+  });
+}
+
+async function loadButtons() {
+  const res = await fetch('/api/buttons');
+  const data = await res.json();
+  const tbody = document.querySelector('#buttons tbody');
+  tbody.innerHTML = '';
+  data.forEach((btn, i) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${btn.name}</td><td>${btn.sound_file}</td><td>${btn.icon}</td><td><span style="background:${btn.color};padding:5px 10px;display:inline-block"></span></td>`;
+    const del = document.createElement('button');
+    del.textContent = 'Delete';
+    del.onclick = async () => {
+      await fetch('/api/buttons/' + i, { method: 'DELETE' });
+      loadButtons();
+    };
+    const td = document.createElement('td');
+    td.appendChild(del);
+    tr.appendChild(td);
+    tbody.appendChild(tr);
+  });
+}
+
+document.getElementById('add-form').onsubmit = async (e) => {
+  e.preventDefault();
+  const name = document.getElementById('name').value;
+  const sound = document.getElementById('sound').value;
+  const color = document.getElementById('color').value;
+  const icon = document.getElementById('icon').value;
+  await fetch('/api/buttons', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, sound_file: sound, color, icon })
+  });
+  e.target.reset();
+  loadButtons();
+};
+
+loadAudio();
+loadButtons();
+</script>
+</body>
+</html>

--- a/static/index.html
+++ b/static/index.html
@@ -8,8 +8,12 @@
 <body>
   <header>
     <img src="/static/logo.svg" alt="PiBells logo" class="logo" />
-    <a href="/admin">Settings</a>
+    <nav>
+      <a href="/admin">Settings</a> |
+      <a href="/buttons">Buttons</a>
+    </nav>
   </header>
+  <div id="quick-buttons"></div>
   <h1>Bell Schedule</h1>
   <div>
     <label>Active schedule:
@@ -27,7 +31,26 @@
     <thead><tr><th>Time</th><th>Sound</th><th>Actions</th></tr></thead>
     <tbody></tbody>
   </table>
-<script>
+  <script>
+async function loadButtons() {
+  const res = await fetch('/api/buttons');
+  const data = await res.json();
+  const container = document.getElementById('quick-buttons');
+  container.innerHTML = '';
+  data.forEach(btn => {
+    const b = document.createElement('button');
+    b.textContent = btn.icon ? btn.icon + ' ' + btn.name : btn.name;
+    b.style.background = btn.color;
+    b.onclick = async () => {
+      await fetch('/api/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sound_file: btn.sound_file })
+      });
+    };
+    container.appendChild(b);
+  });
+}
 async function loadSchedule() {
   const res = await fetch('/api/schedule');
   const data = await res.json();
@@ -110,6 +133,7 @@ document.getElementById('add-form').onsubmit = async (e) => {
 loadScheduleList();
 loadAudio();
 loadSchedule();
+loadButtons();
 </script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -42,3 +42,12 @@ button {
 form {
   margin-top: 20px;
 }
+#quick-buttons button {
+  margin-right: 5px;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+#quick-buttons {
+  margin-bottom: 20px;
+}


### PR DESCRIPTION
## Summary
- add QuickButton model and API for managing quick play buttons
- display quick play buttons on the schedule page
- add buttons configuration page
- style quick button area

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6850ea821a408321845162d059cce379