### PR TITLE
Fix install script with venv setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ script are shown below for reference.
 
    ```bash
    sudo apt update
-   sudo apt install python3 python3-pip git -y
-   pip3 install fastapi uvicorn
+   sudo apt install python3 python3-pip python3-venv git -y
+   python3 -m venv ~/pibells-venv
+   source ~/pibells-venv/bin/activate
+   pip install fastapi uvicorn
    ```
 
 2. **Clone the repository** to the home directory of the `pi` user:
@@ -75,7 +77,7 @@ script are shown below for reference.
    [Service]
    User=pi
    WorkingDirectory=/home/pi/PiBells
-   ExecStart=/usr/bin/env uvicorn app.main:app --host 0.0.0.0
+   ExecStart=/home/pi/pibells-venv/bin/uvicorn app.main:app --host 0.0.0.0
    Restart=always
 
    [Install]

--- a/install.sh
+++ b/install.sh
@@ -11,12 +11,20 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 apt-get update
-apt-get install -y python3 python3-pip git
-
-pip3 install fastapi uvicorn
+apt-get install -y python3 python3-pip python3-venv git
 
 TARGET_USER=${SUDO_USER:-pi}
 HOME_DIR=$(eval echo "~$TARGET_USER")
+
+# set up python virtual environment for the target user
+VENV_DIR="$HOME_DIR/pibells-venv"
+if [ ! -d "$VENV_DIR" ]; then
+  sudo -u "$TARGET_USER" python3 -m venv "$VENV_DIR"
+fi
+
+# install required packages inside the virtual environment
+sudo -u "$TARGET_USER" "$VENV_DIR/bin/pip" install --upgrade pip
+sudo -u "$TARGET_USER" "$VENV_DIR/bin/pip" install fastapi uvicorn
 INSTALL_DIR="$HOME_DIR/PiBells"
 
 if [ -d "$INSTALL_DIR" ]; then
@@ -37,7 +45,7 @@ After=network.target
 [Service]
 User=$TARGET_USER
 WorkingDirectory=$INSTALL_DIR
-ExecStart=/usr/bin/env uvicorn app.main:app --host 0.0.0.0
+ExecStart=$VENV_DIR/bin/uvicorn app.main:app --host 0.0.0.0
 Restart=always
 
 [Install]


### PR DESCRIPTION
## Summary
- create a per-user virtual environment in `install.sh`
- install FastAPI and Uvicorn inside the venv
- run the service with the venv's Uvicorn
- document the new venv steps in the manual installation section of `README.md`

## Testing
- `python3 -m py_compile app/main.py`
- `shellcheck install.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510d92639483218759a2e085dd7088