### PR TITLE
Update user path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ wget -O - https://raw.githubusercontent.com/alinaric/PiBells/main/install.sh | s
 ```
 
 The script installs required packages, clones/updates the repository for the
-`pi` user and creates a `pibells.service` file in `/etc/systemd/system`. The
+`pibells` user and creates a `pibells.service` file in `/etc/systemd/system`. The
 service is then enabled and started so PiBells launches automatically on boot.
 
 If you prefer to perform these steps manually, the commands executed by the
@@ -59,7 +59,7 @@ script are shown below for reference.
    pip install fastapi uvicorn
    ```
 
-2. **Clone the repository** to the home directory of the `pi` user:
+2. **Clone the repository** to the home directory of the `pibells` user:
 
    ```bash
    git clone https://github.com/alinaric/PiBells.git ~/PiBells
@@ -75,9 +75,9 @@ script are shown below for reference.
    After=network.target
 
    [Service]
-   User=pi
-   WorkingDirectory=/home/pi/PiBells
-   ExecStart=/home/pi/pibells-venv/bin/uvicorn app.main:app --host 0.0.0.0
+   User=pibells
+   WorkingDirectory=/home/pibells/PiBells
+   ExecStart=/home/pibells/pibells-venv/bin/uvicorn app.main:app --host 0.0.0.0
    Restart=always
 
    [Install]

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ fi
 apt-get update
 apt-get install -y python3 python3-pip python3-venv git
 
-TARGET_USER=${SUDO_USER:-pi}
+TARGET_USER=${SUDO_USER:-pibells}
 HOME_DIR=$(eval echo "~$TARGET_USER")
 
 # set up python virtual environment for the target user


### PR DESCRIPTION
## Summary
- adjust README installation instructions to use `pibells` user
- default install.sh to use `pibells` user

## Testing
- `python3 -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68510eee94a4832188010aa1050b9742