### PR TITLE
Use port 80 and allow external access

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ A lightweight bell scheduling server using FastAPI. The web interface lets you p
 Start the server with:
 
 ```bash
-uvicorn app.main:app --reload
+sudo uvicorn app.main:app --host 0.0.0.0 --port 80 --reload
 ```
 
-Open your browser at `http://localhost:8000` to manage the schedule.
+Open your browser at `http://<server-ip>/` to manage the schedule.
 
 Bell schedules are stored in `schedule.json`. Multiple schedules can be created and the active one is chosen from the web interface. The server polls this file every 30 seconds and triggers the configured devices for the active schedule.
 
-Device IPs are stored in `devices.json` and can be managed from the admin page at `http://localhost:8000/admin`.
+Device IPs are stored in `devices.json` and can be managed from the admin page at `http://<server-ip>/admin`.
 
 Audio files used for bells can be uploaded from the admin page as well. Uploaded
 files are stored in the `audio/` directory and are selectable when creating
@@ -77,7 +77,7 @@ script are shown below for reference.
    [Service]
    User=pibells
    WorkingDirectory=/home/pibells/PiBells
-   ExecStart=/home/pibells/pibells-venv/bin/uvicorn app.main:app --host 0.0.0.0
+   ExecStart=/home/pibells/pibells-venv/bin/uvicorn app.main:app --host 0.0.0.0 --port 80
    Restart=always
 
    [Install]
@@ -93,4 +93,4 @@ script are shown below for reference.
    ```
 
 PiBells will now automatically start on boot. Access the web interface at
-`http://<raspberrypi-ip>:8000`.
+`http://<raspberrypi-ip>/`.

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 apt-get update
-apt-get install -y python3 python3-pip python3-venv git
+apt-get install -y python3 python3-pip python3-venv git libcap2-bin
 
 TARGET_USER=${SUDO_USER:-pibells}
 HOME_DIR=$(eval echo "~$TARGET_USER")
@@ -25,6 +25,7 @@ fi
 # install required packages inside the virtual environment
 sudo -u "$TARGET_USER" "$VENV_DIR/bin/pip" install --upgrade pip
 sudo -u "$TARGET_USER" "$VENV_DIR/bin/pip" install fastapi uvicorn
+setcap 'cap_net_bind_service=+ep' "$VENV_DIR/bin/python3"
 INSTALL_DIR="$HOME_DIR/PiBells"
 
 if [ -d "$INSTALL_DIR" ]; then
@@ -45,7 +46,7 @@ After=network.target
 [Service]
 User=$TARGET_USER
 WorkingDirectory=$INSTALL_DIR
-ExecStart=$VENV_DIR/bin/uvicorn app.main:app --host 0.0.0.0
+ExecStart=$VENV_DIR/bin/uvicorn app.main:app --host 0.0.0.0 --port 80
 Restart=always
 
 [Install]


### PR DESCRIPTION
## Summary
- expose the FastAPI app on the network and use port 80
- update service file instructions in README
- adjust install script to support port 80

## Testing
- `bash -n install.sh`
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68511a612c308321aa7953aac1560d38