### PR TITLE
Add weekday schedule grid

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ import json
 import socket
 import threading
 import time
-from datetime import datetime
+from datetime import datetime, time as dt_time
 from pathlib import Path
 from typing import Dict, List
 from urllib import request, parse
@@ -24,7 +24,8 @@ app.mount("/audio", StaticFiles(directory=AUDIO_DIR), name="audio")
 app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 
 class ScheduleEntry(BaseModel):
-    time: datetime
+    day: int  # 0=Monday
+    time: dt_time
     sound_file: str
 
 
@@ -143,9 +144,10 @@ def trigger_bell(sound_file: str):
 def bell_daemon():
     while True:
         now = datetime.now().replace(second=0, microsecond=0)
+        weekday = now.weekday()
         events = load_schedule()
         for event in events:
-            if event.time.replace(second=0, microsecond=0) == now:
+            if event.day == weekday and event.time.hour == now.hour and event.time.minute == now.minute:
                 trigger_bell(event.sound_file)
         time.sleep(30)
 

--- a/static/index.html
+++ b/static/index.html
@@ -19,19 +19,13 @@
     <label>Active schedule:
       <select id="schedule-select"></select>
     </label>
+    <button id="set-schedule">Set Schedule</button>
     <input type="text" id="new-schedule" placeholder="New schedule">
     <button id="add-schedule">Add</button>
   </div>
-  <form id="add-form">
-    <label>Date/time: <input type="datetime-local" id="time" required></label>
-    <label>Sound file: <select id="sound"></select></label>
-    <button type="submit">Add</button>
-  </form>
-  <table id="schedule">
-    <thead><tr><th>Time</th><th>Sound</th><th>Actions</th></tr></thead>
-    <tbody></tbody>
-  </table>
+  <div id="schedule-grid" class="schedule-grid"></div>
   <script>
+let audioFiles = [];
 async function loadButtons() {
   const res = await fetch('/api/buttons');
   const data = await res.json();
@@ -54,24 +48,63 @@ async function loadButtons() {
 async function loadSchedule() {
   const res = await fetch('/api/schedule');
   const data = await res.json();
-  const tbody = document.querySelector('#schedule tbody');
-  tbody.innerHTML = '';
-  data.forEach((item, i) => {
-    const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${new Date(item.time).toLocaleString()}</td><td>${item.sound_file}</td>`;
-    const btn = document.createElement('button');
-    btn.textContent = 'Delete';
-    btn.onclick = async () => {
-      await fetch('/api/schedule/' + i, { method: 'DELETE' });
+  const grid = document.getElementById('schedule-grid');
+  grid.innerHTML = '';
+  const days = ['Monday','Tuesday','Wednesday','Thursday','Friday'];
+  for (let d=0; d<5; d++) {
+    const div = document.createElement('div');
+    div.className = 'schedule-day';
+    const h = document.createElement('h3');
+    h.textContent = days[d];
+    div.appendChild(h);
+    const ul = document.createElement('ul');
+    data.map((e,i)=>({...e, index:i}))
+        .filter(e=>e.day===d)
+        .sort((a,b)=>a.time.localeCompare(b.time))
+        .forEach(ev => {
+          const li = document.createElement('li');
+          li.textContent = `${ev.time} - ${ev.sound_file}`;
+          const btn = document.createElement('button');
+          btn.textContent = 'Remove';
+          btn.onclick = async () => {
+            await fetch('/api/schedule/' + ev.index, { method: 'DELETE' });
+            loadSchedule();
+          };
+          li.appendChild(btn);
+          ul.appendChild(li);
+        });
+    div.appendChild(ul);
+    const form = document.createElement('form');
+    form.className = 'add-event-form';
+    const t = document.createElement('input');
+    t.type = 'time';
+    t.required = true;
+    const sel = document.createElement('select');
+    audioFiles.forEach(name => {
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = name;
+      sel.appendChild(opt);
+    });
+    const addBtn = document.createElement('button');
+    addBtn.type = 'submit';
+    addBtn.textContent = 'Add';
+    form.appendChild(t);
+    form.appendChild(sel);
+    form.appendChild(addBtn);
+    form.onsubmit = async (e) => {
+      e.preventDefault();
+      await fetch('/api/schedule', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ day: d, time: t.value, sound_file: sel.value })
+      });
       loadSchedule();
     };
-    const td = document.createElement('td');
-    td.appendChild(btn);
-    tr.appendChild(td);
-    tbody.appendChild(tr);
-  });
+    div.appendChild(form);
+    grid.appendChild(div);
+  }
 }
-
 async function loadScheduleList() {
   const res = await fetch('/api/schedules');
   const data = await res.json();
@@ -85,25 +118,15 @@ async function loadScheduleList() {
     select.appendChild(opt);
   });
 }
-
 async function loadAudio() {
   const res = await fetch('/api/audio');
-  const data = await res.json();
-  const select = document.getElementById('sound');
-  select.innerHTML = '';
-  data.forEach(name => {
-    const opt = document.createElement('option');
-    opt.value = name;
-    opt.textContent = name;
-    select.appendChild(opt);
-  });
+  audioFiles = await res.json();
 }
-
-document.getElementById('schedule-select').onchange = async (e) => {
-  await fetch('/api/schedules/activate/' + encodeURIComponent(e.target.value), { method: 'POST' });
+document.getElementById('set-schedule').onclick = async () => {
+  const name = document.getElementById('schedule-select').value;
+  await fetch('/api/schedules/activate/' + encodeURIComponent(name), { method: 'POST' });
   loadSchedule();
 };
-
 document.getElementById('add-schedule').onclick = async () => {
   const name = document.getElementById('new-schedule').value.trim();
   if (!name) return;
@@ -116,24 +139,9 @@ document.getElementById('add-schedule').onclick = async () => {
   loadScheduleList();
   loadSchedule();
 };
-
-document.getElementById('add-form').onsubmit = async (e) => {
-  e.preventDefault();
-  const time = document.getElementById('time').value;
-  const sound = document.getElementById('sound').value;
-  await fetch('/api/schedule', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ time, sound_file: sound })
-  });
-  e.target.reset();
-  loadSchedule();
-};
-
 loadScheduleList();
-loadAudio();
-loadSchedule();
+loadAudio().then(loadSchedule);
 loadButtons();
-</script>
+  </script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -28,6 +28,26 @@ table {
   margin-top: 20px;
   background: white;
 }
+#schedule-grid {
+  display: flex;
+  gap: 10px;
+  margin-top: 20px;
+}
+.schedule-day {
+  flex: 1;
+  background: white;
+  padding: 10px;
+  border: 1px solid #ccc;
+}
+.schedule-day ul {
+  list-style: none;
+  padding: 0;
+}
+.schedule-day li {
+  display: flex;
+  justify-content: space-between;
+  margin: 4px 0;
+}
 th, td {
   border: 1px solid #ccc;
   padding: 8px;


### PR DESCRIPTION
## Summary
- update schedule entry structure to include day of week and time only
- update daemon to trigger bells based on weekday/time
- redesign index page to show a Monday–Friday grid with add/remove for events
- add basic styles for new grid

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68512f3ab69c8321abb7196d9e08c9e0