### PR TITLE
Fix repo permissions after installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,13 @@ script are shown below for reference.
    cd ~/PiBells
    ```
 
-3. **Create the service file** `/etc/systemd/system/pibells.service` with the following
+3. **Fix directory permissions** so the `pibells` user can update the repo:
+
+   ```bash
+   sudo chown -R pibells:pibells ~/PiBells
+   ```
+
+4. **Create the service file** `/etc/systemd/system/pibells.service` with the following
    contents:
 
    ```ini
@@ -88,7 +94,7 @@ script are shown below for reference.
    WantedBy=multi-user.target
    ```
 
-4. **Enable and start** the service:
+5. **Enable and start** the service:
 
    ```bash
    sudo systemctl daemon-reload
@@ -96,7 +102,7 @@ script are shown below for reference.
    sudo systemctl start pibells
    ```
 
-5. **Configure nginx** to proxy requests on port 80 to the FastAPI server:
+6. **Configure nginx** to proxy requests on port 80 to the FastAPI server:
 
    ```bash
    sudo cp nginx/pibells.conf /etc/nginx/sites-available/pibells

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,9 @@ else
   git clone https://github.com/alinaric/PiBells.git "$INSTALL_DIR"
 fi
 
+# ensure the repository is writable by the target user
+chown -R "$TARGET_USER":"$TARGET_USER" "$INSTALL_DIR"
+
 SERVICE_FILE=/etc/systemd/system/pibells.service
 
 cat > "$SERVICE_FILE" <<SERVICE


### PR DESCRIPTION
## Summary
- ensure PiBells repo is writable by the service user after running `install.sh`
- document the manual step to reset directory permissions when installing manually

## Testing
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_e_6851c4ef85c88321b883c445f8b82b9e