### PR TITLE
Add network device discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Open your browser at `http://<server-ip>/` to manage the schedule.
 Bell schedules are stored in `schedule.json`. Multiple schedules can be created and the active one is chosen from the web interface. The server polls this file every 30 seconds and triggers the configured devices for the active schedule.
 
 Device IPs are stored in `devices.json` and can be managed from the admin page at `http://<server-ip>/admin`.
+The admin page also provides a **Scan Network** button which automatically discovers
+Barix devices on the local subnet and adds them to the list.
 
 Audio files used for bells can be uploaded from the admin page as well. Uploaded
 files are stored in the `audio/` directory and are selectable when creating

--- a/static/admin.html
+++ b/static/admin.html
@@ -15,6 +15,7 @@
     <label>Device IP: <input type="text" id="ip" placeholder="192.168.1.10" required></label>
     <button type="submit">Add</button>
   </form>
+  <button id="scan-btn">Scan Network</button>
   <table id="devices">
     <thead><tr><th>IP</th><th>Actions</th></tr></thead>
     <tbody></tbody>
@@ -76,6 +77,19 @@
 
   loadDevices();
   loadNetwork();
+
+  document.getElementById('scan-btn').onclick = async () => {
+    const res = await fetch('/api/devices/scan');
+    const data = await res.json();
+    for (const ip of data) {
+      await fetch('/api/devices', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ip })
+      });
+    }
+    loadDevices();
+  };
 
   async function loadAudio() {
     const res = await fetch('/api/audio');


### PR DESCRIPTION
## Summary
- implement local network scanning for Barix devices
- expose `/api/devices/scan` endpoint
- add Scan button to admin page
- document network scanning ability

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6859e0bdc56083219d81a16e894ede55