### PR TITLE
Add network selection for device scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Bell schedules are stored in `schedule.json`. Multiple schedules can be created 
 
 Device IPs are stored in `devices.json` and can be managed from the admin page at `http://<server-ip>/admin`.
 The admin page also provides a **Scan Network** button which automatically discovers
-Barix devices on the local subnet and adds them to the list.
+Barix devices on the local subnet and adds them to the list. If your devices are
+on a different subnet you can enter the network prefix (e.g. `192.168.2`) before
+scanning to search that network instead.
 
 Audio files used for bells can be uploaded from the admin page as well. Uploaded
 files are stored in the `audio/` directory and are selectable when creating

--- a/static/admin.html
+++ b/static/admin.html
@@ -15,6 +15,7 @@
     <label>Device IP: <input type="text" id="ip" placeholder="192.168.1.10" required></label>
     <button type="submit">Add</button>
   </form>
+  <label>Network: <input type="text" id="scan-net" placeholder="192.168.1"></label>
   <button id="scan-btn">Scan Network</button>
   <table id="devices">
     <thead><tr><th>IP</th><th>Actions</th></tr></thead>
@@ -79,7 +80,9 @@
   loadNetwork();
 
   document.getElementById('scan-btn').onclick = async () => {
-    const res = await fetch('/api/devices/scan');
+    const net = document.getElementById('scan-net').value;
+    const url = net ? '/api/devices/scan?network=' + encodeURIComponent(net) : '/api/devices/scan';
+    const res = await fetch(url);
     const data = await res.json();
     for (const ip of data) {
       await fetch('/api/devices', {


### PR DESCRIPTION
## Summary
- allow specifying network when searching for Barix devices
- expose network parameter on `/api/devices/scan`
- add network input on admin page
- document scanning different networks

## Testing
- `python -m py_compile app/main.py`
- `python -m py_compile app/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6859e66ab8448321afc0a7075aefa9bc