### PR TITLE
Improve audio management

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -29,6 +29,7 @@
   <h2>Audio Files</h2>
   <form id="upload-form">
     <input type="file" id="audio-file" accept="audio/*" required>
+    <input type="text" id="audio-name" placeholder="Name" required>
     <button type="submit">Upload</button>
   </form>
   <ul id="audio-list"></ul>
@@ -113,14 +114,14 @@
     list.innerHTML = '';
     const testSelect = document.getElementById('test-sound');
     if (testSelect) testSelect.innerHTML = '';
-    data.forEach(name => {
+    data.forEach(file => {
       const li = document.createElement('li');
-      li.textContent = name;
+      li.textContent = file.name;
       list.appendChild(li);
       if (testSelect) {
         const opt = document.createElement('option');
-        opt.value = name;
-        opt.textContent = name;
+        opt.value = file.file;
+        opt.textContent = file.name;
         testSelect.appendChild(opt);
       }
     });
@@ -129,10 +130,13 @@
   document.getElementById('upload-form').onsubmit = async (e) => {
     e.preventDefault();
     const fileInput = document.getElementById('audio-file');
+    const nameInput = document.getElementById('audio-name');
     const formData = new FormData();
     formData.append('file', fileInput.files[0]);
+    formData.append('name', nameInput.value);
     await fetch('/api/audio', { method: 'POST', body: formData });
     fileInput.value = '';
+    nameInput.value = '';
     loadAudio();
   };
 

--- a/static/buttons.html
+++ b/static/buttons.html
@@ -23,17 +23,20 @@
     <tbody></tbody>
   </table>
 <script>
+let audioMap = {};
 async function loadAudio() {
   const res = await fetch('/api/audio');
   const data = await res.json();
   const select = document.getElementById('sound');
   if (!select) return;
   select.innerHTML = '';
-  data.forEach(name => {
+  audioMap = {};
+  data.forEach(file => {
     const opt = document.createElement('option');
-    opt.value = name;
-    opt.textContent = name;
+    opt.value = file.file;
+    opt.textContent = file.name;
     select.appendChild(opt);
+    audioMap[file.file] = file.name;
   });
 }
 
@@ -44,7 +47,8 @@ async function loadButtons() {
   tbody.innerHTML = '';
   data.forEach((btn, i) => {
     const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${btn.name}</td><td>${btn.sound_file}</td><td>${btn.icon}</td><td><span style="background:${btn.color};padding:5px 10px;display:inline-block"></span></td>`;
+    const sound = audioMap[btn.sound_file] || btn.sound_file;
+    tr.innerHTML = `<td>${btn.name}</td><td>${sound}</td><td>${btn.icon}</td><td><span style="background:${btn.color};padding:5px 10px;display:inline-block"></span></td>`;
     const del = document.createElement('button');
     del.textContent = 'Delete';
     del.onclick = async () => {

--- a/static/index.html
+++ b/static/index.html
@@ -26,6 +26,7 @@
   <div id="schedule-grid" class="schedule-grid"></div>
   <script>
 let audioFiles = [];
+let audioMap = {};
 async function loadButtons() {
   const res = await fetch('/api/buttons');
   const data = await res.json();
@@ -63,7 +64,8 @@ async function loadSchedule() {
         .sort((a,b)=>a.time.localeCompare(b.time))
         .forEach(ev => {
           const li = document.createElement('li');
-          li.textContent = `${ev.time} - ${ev.sound_file}`;
+          const display = audioMap[ev.sound_file] || ev.sound_file;
+          li.textContent = `${ev.time} - ${display}`;
           const btn = document.createElement('button');
           btn.textContent = 'Remove';
           btn.onclick = async () => {
@@ -80,10 +82,10 @@ async function loadSchedule() {
     t.type = 'time';
     t.required = true;
     const sel = document.createElement('select');
-    audioFiles.forEach(name => {
+    audioFiles.forEach(file => {
       const opt = document.createElement('option');
-      opt.value = name;
-      opt.textContent = name;
+      opt.value = file.file;
+      opt.textContent = file.name;
       sel.appendChild(opt);
     });
     const addBtn = document.createElement('button');
@@ -121,6 +123,8 @@ async function loadScheduleList() {
 async function loadAudio() {
   const res = await fetch('/api/audio');
   audioFiles = await res.json();
+  audioMap = {};
+  audioFiles.forEach(f => { audioMap[f.file] = f.name; });
 }
 document.getElementById('set-schedule').onclick = async () => {
   const name = document.getElementById('schedule-select').value;


### PR DESCRIPTION
## Summary
- store audio file metadata with display names
- filter audio list to known audio formats
- display audio names instead of file names
- allow specifying a name on upload

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ec53c2348321a1ed0f9586f1c1e8