### PR TITLE
Add live clock to main page

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -13,6 +13,7 @@
       <a href="/buttons">Buttons</a>
     </nav>
   </header>
+  <div id="current-time"></div>
   <div id="quick-buttons"></div>
   <h1>Bell Schedule</h1>
   <div>
@@ -146,6 +147,14 @@ document.getElementById('add-schedule').onclick = async () => {
 loadScheduleList();
 loadAudio().then(loadSchedule);
 loadButtons();
+function updateTime() {
+  const now = new Date();
+  const pad = n => n.toString().padStart(2, '0');
+  const str = `${pad(now.getHours())}:${pad(now.getMinutes())}:${pad(now.getSeconds())}`;
+  document.getElementById('current-time').textContent = str;
+}
+updateTime();
+setInterval(updateTime, 1000);
   </script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -76,6 +76,13 @@ form {
   margin-bottom: 20px;
 }
 
+#current-time {
+  text-align: center;
+  font-size: 3em;
+  font-family: 'Courier New', monospace;
+  margin-bottom: 20px;
+}
+
 #scan-progress {
   margin-left: 10px;
   width: 200px;


### PR DESCRIPTION
## Summary
- show current time on the home page
- update style for clock display

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859edf011ac832197cc03ae5cfaa4de