### PR TITLE
Adjust header layout

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -9,11 +9,11 @@
 <body>
   <header>
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
+    <div id="current-time"></div>
     <nav>
       <a href="/admin"><i class="fas fa-cog"></i> Settings</a> |
       <a href="/buttons"><i class="fas fa-bell"></i> Buttons</a>
     </nav>
-    <div id="current-time"></div>
   </header>
   <div id="quick-buttons"></div>
   <h1>Bell Schedule</h1>

--- a/static/style.css
+++ b/static/style.css
@@ -7,12 +7,15 @@ body {
 header {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   margin-bottom: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 5px rgba(0,0,0,0.3);
   background: white;
   padding: 10px 20px;
+}
+
+header nav {
+  margin-left: auto;
 }
 header img.logo {
   height: 50px;
@@ -89,7 +92,8 @@ form {
 }
 
 #current-time {
-  text-align: right;
+  flex: 1;
+  text-align: center;
   font-size: 3em;
   font-family: 'Courier New', monospace;
   margin: 0;


### PR DESCRIPTION
## Summary
- center the time display
- move navigation links to the right side

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6859f2dd7ae48321bb0e1663f8b15db8