### PR TITLE
Add device status polling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -315,6 +315,25 @@ def delete_device(index: int):
     return devices
 
 
+def check_device(ip: str, timeout: float = 0.5) -> bool:
+    """Return True if the device responds on port 80."""
+    try:
+        with socket.create_connection((ip, 80), timeout=timeout) as sock:
+            sock.sendall(b"GET / HTTP/1.0\r\n\r\n")
+            sock.recv(100)
+        return True
+    except Exception:
+        return False
+
+
+@app.get("/api/devices/status", response_model=Dict[str, bool])
+def devices_status():
+    """Check online status of configured devices."""
+    devices = load_devices()
+    status = {ip: check_device(ip) for ip in devices}
+    return status
+
+
 @app.get("/api/devices/scan", response_model=List[str])
 def scan_devices(network: Optional[str] = None):
     """Discover Barix devices on the specified network."""

--- a/static/admin.html
+++ b/static/admin.html
@@ -20,7 +20,7 @@
   <button id="scan-btn"><i class="fas fa-search"></i> Scan Network</button>
   <progress id="scan-progress" value="0" max="254" style="display:none;"></progress>
   <table id="devices">
-    <thead><tr><th>IP</th><th>Actions</th></tr></thead>
+    <thead><tr><th>IP</th><th>Status</th><th>Actions</th></tr></thead>
     <tbody></tbody>
   </table>
 
@@ -55,19 +55,40 @@
     tbody.innerHTML = '';
     data.forEach((ip, i) => {
       const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${ip}</td>`;
+      const ipTd = document.createElement('td');
+      ipTd.textContent = ip;
+      const statusTd = document.createElement('td');
+      statusTd.innerHTML = '<i class="fas fa-circle status-icon" data-ip="' + ip + '"></i>';
       const btn = document.createElement('button');
       btn.innerHTML = '<i class="fas fa-trash"></i> Delete';
       btn.onclick = async () => {
         await fetch('/api/devices/' + i, { method: 'DELETE' });
         loadDevices();
       };
-      const td = document.createElement('td');
-      td.appendChild(btn);
-      tr.appendChild(td);
+      const actionTd = document.createElement('td');
+      actionTd.appendChild(btn);
+      tr.appendChild(ipTd);
+      tr.appendChild(statusTd);
+      tr.appendChild(actionTd);
       tbody.appendChild(tr);
     });
+    updateStatuses();
   }
+
+  async function updateStatuses() {
+    const res = await fetch('/api/devices/status');
+    const data = await res.json();
+    document.querySelectorAll('.status-icon').forEach(icon => {
+      const ip = icon.dataset.ip;
+      if (data[ip]) {
+        icon.style.color = 'green';
+      } else {
+        icon.style.color = 'red';
+      }
+    });
+  }
+
+  setInterval(updateStatuses, 5000);
 
   document.getElementById('add-form').onsubmit = async (e) => {
     e.preventDefault();

--- a/static/style.css
+++ b/static/style.css
@@ -131,3 +131,7 @@ form {
   gap: 10px;
   margin-top: 10px;
 }
+
+.status-icon {
+  font-size: 1.2em;
+}


### PR DESCRIPTION
## Summary
- add REST endpoint to check if configured devices are online
- show device status icons in the admin page
- poll device status every few seconds

## Testing
- `pytest -q`
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6859f60eaec08321a9219c44ed2df272