### PR TITLE
Add hostname footer with branding

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -365,8 +365,8 @@ def scan_devices_stream(network: Optional[str] = None):
 
 @app.get("/api/network")
 def network_info():
-    """Return network information such as the current IP address."""
-    return {"ip": get_local_ip()}
+    """Return network information such as the current IP address and hostname."""
+    return {"ip": get_local_ip(), "hostname": socket.gethostname()}
 
 
 def list_audio() -> List[AudioFile]:

--- a/static/admin.html
+++ b/static/admin.html
@@ -192,5 +192,24 @@
     });
   };
   </script>
+  <footer>
+    <div class="footer-left">
+      <img src="/static/smallroundlogo.png" alt="PixelPacific logo" class="footer-logo" />
+      <span>&copy; 2025 <a href="https://www.pixelpacific.com" target="_blank">PixelPacific LLC.</a></span>
+    </div>
+    <div id="hostname" class="footer-right"></div>
+  </footer>
+  <script>
+  async function loadHostname() {
+    try {
+      const res = await fetch('/api/network');
+      const data = await res.json();
+      document.getElementById('hostname').textContent = data.hostname;
+    } catch (e) {
+      console.error(e);
+    }
+  }
+  loadHostname();
+  </script>
 </body>
 </html>

--- a/static/buttons.html
+++ b/static/buttons.html
@@ -81,5 +81,24 @@ document.getElementById('add-form').onsubmit = async (e) => {
 loadAudio();
 loadButtons();
 </script>
+  <footer>
+    <div class="footer-left">
+      <img src="/static/smallroundlogo.png" alt="PixelPacific logo" class="footer-logo" />
+      <span>&copy; 2025 <a href="https://www.pixelpacific.com" target="_blank">PixelPacific LLC.</a></span>
+    </div>
+    <div id="hostname" class="footer-right"></div>
+  </footer>
+  <script>
+  async function loadHostname() {
+    try {
+      const res = await fetch('/api/network');
+      const data = await res.json();
+      document.getElementById('hostname').textContent = data.hostname;
+    } catch (e) {
+      console.error(e);
+    }
+  }
+  loadHostname();
+  </script>
 </body>
 </html>

--- a/static/index.html
+++ b/static/index.html
@@ -162,5 +162,24 @@ function updateTime() {
 updateTime();
 setInterval(updateTime, 1000);
   </script>
+  <footer>
+    <div class="footer-left">
+      <img src="/static/smallroundlogo.png" alt="PixelPacific logo" class="footer-logo" />
+      <span>&copy; 2025 <a href="https://www.pixelpacific.com" target="_blank">PixelPacific LLC.</a></span>
+    </div>
+    <div id="hostname" class="footer-right"></div>
+  </footer>
+  <script>
+  async function loadHostname() {
+    try {
+      const res = await fetch('/api/network');
+      const data = await res.json();
+      document.getElementById('hostname').textContent = data.hostname;
+    } catch (e) {
+      console.error(e);
+    }
+  }
+  loadHostname();
+  </script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -135,3 +135,35 @@ form {
 .status-icon {
   font-size: 1.2em;
 }
+
+footer {
+  margin-top: 40px;
+  padding: 10px 20px;
+  background: #222;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+}
+
+footer .footer-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+footer img.footer-logo {
+  height: 30px;
+}
+
+footer a {
+  color: #fff;
+  text-decoration: underline;
+}
+
+footer .footer-right {
+  margin-left: auto;
+  text-align: right;
+}


### PR DESCRIPTION
## Summary
- style up the footer
- include hostname, PixelPacific logo and link to PixelPacific
- expose hostname via `/api/network`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f90486a48321b76eb6ef3dc0ca79