### PR TITLE
Add built-in quick button icons

### DIFF
--- a/static/buttons.html
+++ b/static/buttons.html
@@ -16,7 +16,15 @@
     <label>Name: <input type="text" id="name" required></label>
     <label>Sound: <select id="sound"></select></label>
     <label>Color: <input type="color" id="color" value="#ff0000"></label>
-    <label>Icon: <input type="text" id="icon" placeholder="emoji or icon"></label>
+    <label>Icon:
+      <select id="icon">
+        <option value="">None</option>
+        <option value="fa-bell">Bell</option>
+        <option value="fa-fire">Fire</option>
+        <option value="fa-exclamation-triangle">Warning</option>
+        <option value="fa-ambulance">Ambulance</option>
+      </select>
+    </label>
     <button type="submit"><i class="fas fa-plus"></i> Add</button>
   </form>
   <table id="buttons">
@@ -49,7 +57,8 @@ async function loadButtons() {
   data.forEach((btn, i) => {
     const tr = document.createElement('tr');
     const sound = audioMap[btn.sound_file] || btn.sound_file;
-    tr.innerHTML = `<td>${btn.name}</td><td>${sound}</td><td>${btn.icon}</td><td><span style="background:${btn.color};padding:5px 10px;display:inline-block"></span></td>`;
+    const iconHtml = btn.icon ? `<i class="fas ${btn.icon}"></i>` : '';
+    tr.innerHTML = `<td>${btn.name}</td><td>${sound}</td><td>${iconHtml}</td><td><span style="background:${btn.color};padding:5px 10px;display:inline-block"></span></td>`;
     const del = document.createElement('button');
     del.innerHTML = '<i class="fas fa-trash"></i> Delete';
     del.onclick = async () => {

--- a/static/index.html
+++ b/static/index.html
@@ -36,7 +36,11 @@ async function loadButtons() {
   container.innerHTML = '';
   data.forEach(btn => {
     const b = document.createElement('button');
-    b.textContent = btn.icon ? btn.icon + ' ' + btn.name : btn.name;
+    if (btn.icon) {
+      b.innerHTML = `<i class="fas ${btn.icon}"></i> ${btn.name}`;
+    } else {
+      b.textContent = btn.name;
+    }
     b.style.background = btn.color;
     b.onclick = async () => {
       await fetch('/api/test', {


### PR DESCRIPTION
## Summary
- offer predefined icons when configuring quick buttons
- render selected icons with Font Awesome on the schedule page

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685a0999e5bc8321983889ea5dd69610