### PR TITLE
Add clock to admin and buttons headers

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -9,7 +9,10 @@
 <body>
   <header>
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
-    <a href="/"><i class="fas fa-arrow-left"></i> Back to Schedule</a>
+    <div id="current-time"></div>
+    <nav>
+      <a href="/"><i class="fas fa-arrow-left"></i> Back to Schedule</a>
+    </nav>
   </header>
   <h1>Barix Devices</h1>
   <form id="add-form">
@@ -223,6 +226,19 @@
   };
 
   loadVersion();
+  function updateTime() {
+    const now = new Date();
+    const pad = n => n.toString().padStart(2, '0');
+    const days = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+    let hours = now.getHours();
+    const ampm = hours >= 12 ? 'PM' : 'AM';
+    hours = hours % 12;
+    if (hours === 0) hours = 12;
+    const str = `${days[now.getDay()]} ${pad(hours)}:${pad(now.getMinutes())}:${pad(now.getSeconds())} ${ampm}`;
+    document.getElementById('current-time').textContent = str;
+  }
+  updateTime();
+  setInterval(updateTime, 1000);
   </script>
   <footer>
     <div class="footer-left">

--- a/static/buttons.html
+++ b/static/buttons.html
@@ -9,7 +9,10 @@
 <body>
   <header>
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
-    <a href="/"><i class="fas fa-arrow-left"></i> Back to Schedule</a>
+    <div id="current-time"></div>
+    <nav>
+      <a href="/"><i class="fas fa-arrow-left"></i> Back to Schedule</a>
+    </nav>
   </header>
   <h1>Quick Buttons</h1>
   <form id="add-form">
@@ -87,8 +90,21 @@ document.getElementById('add-form').onsubmit = async (e) => {
   loadButtons();
 };
 
-loadAudio();
-loadButtons();
+  loadAudio();
+  loadButtons();
+  function updateTime() {
+    const now = new Date();
+    const pad = n => n.toString().padStart(2, '0');
+    const days = ['Sunday','Monday','Tuesday','Wednesday','Thursday','Friday','Saturday'];
+    let hours = now.getHours();
+    const ampm = hours >= 12 ? 'PM' : 'AM';
+    hours = hours % 12;
+    if (hours === 0) hours = 12;
+    const str = `${days[now.getDay()]} ${pad(hours)}:${pad(now.getMinutes())}:${pad(now.getSeconds())} ${ampm}`;
+    document.getElementById('current-time').textContent = str;
+  }
+  updateTime();
+  setInterval(updateTime, 1000);
 </script>
   <footer>
     <div class="footer-left">


### PR DESCRIPTION
## Summary
- replicate schedule page header layout on admin and buttons pages
- display current time on admin and buttons pages

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685a0c4dcb448321a4b81eefdafc5bc9