### PR TITLE
Support local and concurrent audio playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License: PPPL 1.0](https://img.shields.io/badge/License-PPPL%201.0-blue)](LICENSE)
 [![PixelPacific](https://img.shields.io/badge/PixelPacific-Website-blue)](https://pixelpacific.com)
 
-PiBells is a lightweight bell scheduling server built with FastAPI. The web interface lets you pick a time and sound file for each bell. When a bell is due, the server sends play requests to Barix devices on the network.
+PiBells is a lightweight bell scheduling server built with FastAPI. The web interface lets you pick a time and sound file for each bell. When a bell is due, the server sends play requests to Barix devices on the network and plays the sound through the local sound card.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- play audio locally when triggered and send requests to all devices concurrently
- document that bells also play over the local sound card

## Testing
- `python3 -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685a10d3980c8321baf388a33aaa1f08