### PR TITLE
Add authentication with local account check

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -11,7 +11,8 @@
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
     <div id="current-time"></div>
     <nav>
-      <a href="/"><i class="fas fa-arrow-left"></i> Back to Schedule</a>
+      <a href="/"><i class="fas fa-arrow-left"></i> Back to Schedule</a> |
+      <a href="/logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
     </nav>
   </header>
   <h1>Barix Devices</h1>

--- a/static/buttons.html
+++ b/static/buttons.html
@@ -11,7 +11,8 @@
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
     <div id="current-time"></div>
     <nav>
-      <a href="/"><i class="fas fa-arrow-left"></i> Back to Schedule</a>
+      <a href="/"><i class="fas fa-arrow-left"></i> Back to Schedule</a> |
+      <a href="/logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
     </nav>
   </header>
   <h1>Quick Buttons</h1>

--- a/static/index.html
+++ b/static/index.html
@@ -12,7 +12,8 @@
     <div id="current-time"></div>
     <nav>
       <a href="/admin"><i class="fas fa-cog"></i> Settings</a> |
-      <a href="/buttons"><i class="fas fa-bell"></i> Buttons</a>
+      <a href="/buttons"><i class="fas fa-bell"></i> Buttons</a> |
+      <a href="/logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
     </nav>
   </header>
   <div id="quick-buttons"></div>

--- a/static/login.html
+++ b/static/login.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Login - PiBells</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <div class="login-container">
+    <img src="/static/pibells-logo.png" alt="PiBells logo" class="login-logo" />
+    <form id="login-form" method="post" action="/login">
+      <label>Username:<br><input type="text" name="username" required></label>
+      <label>Password:<br><input type="password" name="password" required></label>
+      <label class="remember"><input type="checkbox" name="remember"> Remember me</label>
+      <button type="submit">Login</button>
+    </form>
+    <div id="error-msg" style="color:red;"></div>
+  </div>
+<script>
+const params = new URLSearchParams(window.location.search);
+if (params.get('error')) {
+  document.getElementById('error-msg').textContent = 'Invalid username or password';
+}
+</script>
+</body>
+</html>

--- a/static/style.css
+++ b/static/style.css
@@ -218,3 +218,29 @@ footer .footer-right {
   gap: 8px;
   margin-top: 10px;
 }
+
+.login-container {
+  max-width: 300px;
+  margin: 100px auto;
+  background: var(--table-bg);
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+  text-align: center;
+}
+
+.login-container label {
+  display: block;
+  margin: 10px 0;
+}
+
+.login-container input[type="text"],
+.login-container input[type="password"] {
+  width: 100%;
+  padding: 8px;
+}
+
+.login-logo {
+  height: 60px;
+  margin-bottom: 10px;
+}


### PR DESCRIPTION
## Summary
- implement session-based authentication using local system accounts
- add login and logout endpoints with middleware to guard routes
- create login page and update CSS for form styling
- add logout button to site navigation

## Testing
- `python3 -m py_compile app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a13d206c4832187de28d461e7cd8c