### PR TITLE
Add update progress feedback

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -52,6 +52,8 @@
   <p id="version-display"></p>
   <button id="check-version"><i class="fas fa-sync"></i> Check for Updates</button>
   <button id="update-btn"><i class="fas fa-download"></i> Update</button>
+  <progress id="update-progress" value="0" max="100" style="display:none;"></progress>
+  <span id="update-step" style="display:none;margin-left:10px;"></span>
   <script>
   async function loadNetwork() {
     const res = await fetch('/api/network');
@@ -219,19 +221,31 @@
 
   document.getElementById('check-version').onclick = loadVersion;
 
-  document.getElementById('update-btn').onclick = async () => {
+  document.getElementById('update-btn').onclick = () => {
     if (!confirm('Update PiBells now?')) return;
     const btn = document.getElementById('update-btn');
+    const progress = document.getElementById('update-progress');
+    const step = document.getElementById('update-step');
     btn.disabled = true;
-    try {
-      const res = await fetch('/api/update', { method: 'POST' });
-      const data = await res.json();
-      alert(data.status);
-    } catch (e) {
-      alert('Update failed');
-    }
-    btn.disabled = false;
-    loadVersion();
+    progress.value = 0;
+    progress.style.display = 'inline';
+    step.textContent = '';
+    step.style.display = 'inline';
+    const es = new EventSource('/api/update_stream');
+    es.onmessage = (e) => {
+      const data = JSON.parse(e.data);
+      if ('progress' in data) progress.value = data.progress;
+      if (data.step) step.textContent = data.step;
+      if (data.complete || data.error) {
+        es.close();
+        progress.style.display = 'none';
+        step.style.display = 'none';
+        btn.disabled = false;
+        if (data.error) alert(data.error);
+        else alert('Update complete');
+        loadVersion();
+      }
+    };
   };
 
   loadVersion();

--- a/static/style.css
+++ b/static/style.css
@@ -132,6 +132,11 @@ form {
   width: 200px;
 }
 
+#update-progress {
+  margin-left: 10px;
+  width: 200px;
+}
+
 .audio-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));


### PR DESCRIPTION
## Summary
- stream update progress from backend
- show progress bar and step text while updating

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a22eb3ae483219357c190109319d4