### PR TITLE
Improve footer layout and theme selector icons

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -265,9 +265,9 @@
   </script>
   <div class="theme-switch">
     <select id="theme-select">
-      <option value="auto">Auto</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
+      <option value="auto">&#xf042; Auto</option>
+      <option value="light">&#xf185; Light</option>
+      <option value="dark">&#xf186; Dark</option>
     </select>
   </div>
   <footer>

--- a/static/buttons.html
+++ b/static/buttons.html
@@ -109,9 +109,9 @@ document.getElementById('add-form').onsubmit = async (e) => {
 </script>
   <div class="theme-switch">
     <select id="theme-select">
-      <option value="auto">Auto</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
+      <option value="auto">&#xf042; Auto</option>
+      <option value="light">&#xf185; Light</option>
+      <option value="dark">&#xf186; Dark</option>
     </select>
   </div>
   <footer>

--- a/static/index.html
+++ b/static/index.html
@@ -198,9 +198,9 @@ updateTime();
   </script>
   <div class="theme-switch">
     <select id="theme-select">
-      <option value="auto">Auto</option>
-      <option value="light">Light</option>
-      <option value="dark">Dark</option>
+      <option value="auto">&#xf042; Auto</option>
+      <option value="light">&#xf185; Light</option>
+      <option value="dark">&#xf186; Dark</option>
     </select>
   </div>
   <footer>

--- a/static/style.css
+++ b/static/style.css
@@ -13,7 +13,7 @@
 body {
   font-family: Arial, sans-serif;
   margin: 0;
-  padding: 40px;
+  padding: 20px 40px;
   background: var(--bg-color);
   color: var(--text-color);
   display: flex;
@@ -211,6 +211,10 @@ footer .footer-right {
   border-radius: 8px;
   padding: 5px;
   box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+}
+.theme-switch select {
+  font-family: "Font Awesome 6 Free", Arial, sans-serif;
+  font-weight: 900;
 }
 
 .network-info {


### PR DESCRIPTION
## Summary
- reduce body padding so footer fits without scrolling
- style theme selector for FontAwesome icons
- add icons to theme selection options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a26de5404832194e37ecdfb7cd94e