### PR TITLE
Move theme switch to settings page

### DIFF
--- a/static/buttons.html
+++ b/static/buttons.html
@@ -107,13 +107,6 @@ document.getElementById('add-form').onsubmit = async (e) => {
   updateTime();
   setInterval(updateTime, 1000);
 </script>
-  <div class="theme-switch">
-    <select id="theme-select">
-      <option value="auto">&#xf042; Auto</option>
-      <option value="light">&#xf185; Light</option>
-      <option value="dark">&#xf186; Dark</option>
-    </select>
-  </div>
   <footer>
     <div class="footer-left">
       <img src="/static/smallroundlogo.png" alt="PixelPacific logo" class="footer-logo" />

--- a/static/index.html
+++ b/static/index.html
@@ -196,13 +196,6 @@ function updateTime() {
 updateTime();
   setInterval(updateTime, 1000);
   </script>
-  <div class="theme-switch">
-    <select id="theme-select">
-      <option value="auto">&#xf042; Auto</option>
-      <option value="light">&#xf185; Light</option>
-      <option value="dark">&#xf186; Dark</option>
-    </select>
-  </div>
   <footer>
     <div class="footer-left">
       <img src="/static/smallroundlogo.png" alt="PixelPacific logo" class="footer-logo" />

--- a/static/style.css
+++ b/static/style.css
@@ -208,13 +208,16 @@ footer .footer-right {
   background: var(--header-bg);
   color: var(--text-color);
   border: 1px solid var(--table-border);
-  border-radius: 8px;
-  padding: 5px;
+  border-radius: 12px;
+  padding: 15px 20px;
   box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+  font-size: 1.5em;
 }
 .theme-switch select {
   font-family: "Font Awesome 6 Free", Arial, sans-serif;
   font-weight: 900;
+  font-size: 1em;
+  padding: 5px 10px;
 }
 
 .network-info {

--- a/static/theme.js
+++ b/static/theme.js
@@ -10,12 +10,13 @@ function applyTheme(mode) {
 }
 
 function initTheme() {
-  const select = document.getElementById('theme-select');
-  if (!select) return;
   const saved = localStorage.getItem('theme') || 'auto';
   applyTheme(saved);
-  select.value = saved;
-  select.addEventListener('change', (e) => applyTheme(e.target.value));
+  const select = document.getElementById('theme-select');
+  if (select) {
+    select.value = saved;
+    select.addEventListener('change', (e) => applyTheme(e.target.value));
+  }
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
     if (localStorage.getItem('theme') === 'auto') applyTheme('auto');
   });


### PR DESCRIPTION
## Summary
- tweak theme handling so the switch is optional
- make the selector larger via CSS
- remove the theme selector from the schedule and buttons pages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2b6a17488321ba692799b7082b00