### PR TITLE
Ensure footer is visible without scrolling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -14,6 +14,7 @@ body {
   font-family: Arial, sans-serif;
   margin: 0;
   padding: 20px 40px;
+  box-sizing: border-box;
   background: var(--bg-color);
   color: var(--text-color);
   display: flex;


### PR DESCRIPTION
## Summary
- make body `min-height` include padding so footer stays on screen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2c7bc9a48321ae4022c6baf164f9