### PR TITLE
Restore theme selector and restyle

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -264,10 +264,11 @@
   setInterval(updateTime, 1000);
   </script>
   <div class="theme-switch">
+    <label for="theme-select">Theme:</label>
     <select id="theme-select">
-      <option value="auto">&#xf042; Auto</option>
-      <option value="light">&#xf185; Light</option>
-      <option value="dark">&#xf186; Dark</option>
+      <option value="auto">Auto</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
     </select>
   </div>
   <footer>

--- a/static/buttons.html
+++ b/static/buttons.html
@@ -107,6 +107,14 @@ document.getElementById('add-form').onsubmit = async (e) => {
   updateTime();
   setInterval(updateTime, 1000);
 </script>
+  <div class="theme-switch">
+    <label for="theme-select">Theme:</label>
+    <select id="theme-select">
+      <option value="auto">Auto</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </div>
   <footer>
     <div class="footer-left">
       <img src="/static/smallroundlogo.png" alt="PixelPacific logo" class="footer-logo" />

--- a/static/index.html
+++ b/static/index.html
@@ -196,6 +196,14 @@ function updateTime() {
 updateTime();
   setInterval(updateTime, 1000);
   </script>
+  <div class="theme-switch">
+    <label for="theme-select">Theme:</label>
+    <select id="theme-select">
+      <option value="auto">Auto</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </div>
   <footer>
     <div class="footer-left">
       <img src="/static/smallroundlogo.png" alt="PixelPacific logo" class="footer-logo" />

--- a/static/login.html
+++ b/static/login.html
@@ -22,5 +22,14 @@ if (params.get('error')) {
   document.getElementById('error-msg').textContent = 'Invalid username or password';
 }
 </script>
+<div class="theme-switch">
+  <label for="theme-select">Theme:</label>
+  <select id="theme-select">
+    <option value="auto">Auto</option>
+    <option value="light">Light</option>
+    <option value="dark">Dark</option>
+  </select>
+</div>
+<script src="/static/theme.js"></script>
 </body>
 </html>

--- a/static/style.css
+++ b/static/style.css
@@ -203,22 +203,17 @@ footer .footer-right {
 }
 
 .theme-switch {
-  position: fixed;
-  right: 20px;
-  bottom: 80px;
-  background: var(--header-bg);
-  color: var(--text-color);
-  border: 1px solid var(--table-border);
-  border-radius: 12px;
-  padding: 15px 20px;
-  box-shadow: 0 2px 5px rgba(0,0,0,0.3);
-  font-size: 1.5em;
+  margin: 20px auto;
+  text-align: center;
+}
+.theme-switch label {
+  margin-right: 5px;
+  font-size: 0.9em;
 }
 .theme-switch select {
-  font-family: "Font Awesome 6 Free", Arial, sans-serif;
-  font-weight: 900;
-  font-size: 1em;
-  padding: 5px 10px;
+  font-size: 0.9em;
+  padding: 4px 8px;
+  border-radius: 4px;
 }
 
 .network-info {


### PR DESCRIPTION
## Summary
- reintroduce the theme selector at the bottom of every page
- redesign theme selector styling to be small and simple

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a2e347f688321b2dcda95c5243ea4