### PR TITLE
Add reboot option

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -479,6 +479,16 @@ def update_repo_stream():
     return StreamingResponse(event_gen(), media_type="text/event-stream")
 
 
+@app.post("/api/reboot")
+def reboot_device():
+    """Reboot the host system."""
+    try:
+        subprocess.Popen(["sudo", "reboot"])
+        return {"status": "rebooting"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Reboot failed: {e}")
+
+
 def list_audio() -> List[AudioFile]:
     meta = load_audio_meta()
     files: List[AudioFile] = []

--- a/static/admin.html
+++ b/static/admin.html
@@ -52,6 +52,7 @@
   <p id="version-display"></p>
   <button id="check-version"><i class="fas fa-sync"></i> Check for Updates</button>
   <button id="update-btn"><i class="fas fa-download"></i> Update</button>
+  <button id="reboot-btn"><i class="fas fa-power-off"></i> Reboot</button>
   <progress id="update-progress" value="0" max="100" style="display:none;"></progress>
   <span id="update-step" style="display:none;margin-left:10px;"></span>
   <script>
@@ -246,6 +247,11 @@
         loadVersion();
       }
     };
+  };
+
+  document.getElementById('reboot-btn').onclick = async () => {
+    if (!confirm('Reboot the device now?')) return;
+    await fetch('/api/reboot', { method: 'POST' });
   };
 
   loadVersion();


### PR DESCRIPTION
## Summary
- add `/api/reboot` endpoint that issues a reboot command
- expose a Reboot button on the admin page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a3336a8b4832189793d31ac39b443