### PR TITLE
Fix icons offline and unify button style

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -4,24 +4,23 @@
   <meta charset="UTF-8" />
   <title>Device Configuration</title>
   <link rel="stylesheet" href="/static/style.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="settings-page">
   <header>
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
     <div id="current-time"></div>
     <nav>
-      <a href="/"><i class="fas fa-arrow-left"></i> Back to Schedule</a> |
-      <a href="/logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
+      <a href="/"><span class="icon">←</span> Back to Schedule</a> |
+      <a href="/logout"><span class="icon">🚪</span> Logout</a>
     </nav>
   </header>
   <h1>Barix Devices</h1>
   <form id="add-form">
     <label>Device IP: <input type="text" id="ip" placeholder="192.168.1.10" required></label>
-    <button type="submit"><i class="fas fa-plus"></i> Add</button>
+    <button type="submit" class="btn"><span class="icon">➕</span> Add</button>
   </form>
   <label>Network: <input type="text" id="scan-net" placeholder="192.168.1"></label>
-  <button id="scan-btn"><i class="fas fa-search"></i> Scan Network</button>
+  <button id="scan-btn" class="btn"><span class="icon">🔍</span> Scan Network</button>
   <progress id="scan-progress" value="0" max="254" style="display:none;"></progress>
   <table id="devices">
     <thead><tr><th>IP</th><th>Status</th><th>Actions</th></tr></thead>
@@ -30,7 +29,7 @@
 
   <h2>Network</h2>
   <div id="network-info" class="network-info">
-    <i class="fas fa-network-wired"></i>
+    <span class="icon">🖧</span>
     <span id="hostname-display"></span> - <span id="ip-display"></span>
   </div>
 
@@ -38,21 +37,21 @@
   <form id="upload-form">
     <input type="file" id="audio-file" accept="audio/*" required>
     <input type="text" id="audio-name" placeholder="Name" required>
-    <button type="submit"><i class="fas fa-upload"></i> Upload</button>
+    <button type="submit" class="btn"><span class="icon">⬆️</span> Upload</button>
   </form>
   <div id="audio-list" class="audio-grid"></div>
 
   <h2>Test</h2>
   <div class="test-section">
     <label>Sound file: <select id="test-sound"></select></label>
-    <button id="test-play"><i class="fas fa-play"></i> Play</button>
+    <button id="test-play" class="btn"><span class="icon">▶️</span> Play</button>
   </div>
 
   <h2>Software</h2>
   <p id="version-display"></p>
-  <button id="check-version"><i class="fas fa-sync"></i> Check for Updates</button>
-  <button id="update-btn"><i class="fas fa-download"></i> Update</button>
-  <button id="reboot-btn"><i class="fas fa-power-off"></i> Reboot</button>
+  <button id="check-version" class="btn"><span class="icon">🔄</span> Check for Updates</button>
+  <button id="update-btn" class="btn"><span class="icon">⬇️</span> Update</button>
+  <button id="reboot-btn" class="btn"><span class="icon">⏻</span> Reboot</button>
   <div id="update-message" class="update-message" style="display:none;"></div>
   <script>
   async function loadNetwork() {
@@ -74,9 +73,10 @@
       const ipTd = document.createElement('td');
       ipTd.textContent = ip;
       const statusTd = document.createElement('td');
-      statusTd.innerHTML = '<i class="fas fa-circle status-icon" data-ip="' + ip + '"></i>';
+      statusTd.innerHTML = '<span class="status-icon icon" data-ip="' + ip + '">●</span>';
       const btn = document.createElement('button');
-      btn.innerHTML = '<i class="fas fa-trash"></i> Delete';
+      btn.className = 'btn';
+      btn.innerHTML = '<span class="icon">🗑</span> Delete';
       btn.onclick = async () => {
         await fetch('/api/devices/' + i, { method: 'DELETE' });
         loadDevices();
@@ -161,7 +161,8 @@
       span.textContent = file.name;
       div.appendChild(span);
       const edit = document.createElement('button');
-      edit.innerHTML = '<i class="fas fa-edit"></i>';
+      edit.className = 'btn';
+      edit.innerHTML = '<span class="icon">✏️</span>';
       edit.onclick = async () => {
         const name = prompt('New name:', file.name);
         if (!name) return;
@@ -230,7 +231,7 @@
     try {
       const res = await fetch('/api/update', { method: 'POST' });
       if (!res.ok) throw new Error('Update failed');
-      msg.innerHTML = '<i class="fas fa-check-circle"></i> Update complete, please reboot system.';
+      msg.innerHTML = '<span class="icon">✅</span> Update complete, please reboot system.';
       msg.style.display = 'inline-flex';
     } catch (e) {
       alert(e);

--- a/static/buttons.html
+++ b/static/buttons.html
@@ -4,15 +4,14 @@
   <meta charset="UTF-8" />
   <title>Button Configuration</title>
   <link rel="stylesheet" href="/static/style.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
   <header>
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
     <div id="current-time"></div>
     <nav>
-      <a href="/"><i class="fas fa-arrow-left"></i> Back to Schedule</a> |
-      <a href="/logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
+      <a href="/"><span class="icon">←</span> Back to Schedule</a> |
+      <a href="/logout"><span class="icon">🚪</span> Logout</a>
     </nav>
   </header>
   <h1>Quick Buttons</h1>
@@ -23,13 +22,13 @@
     <label>Icon:
       <select id="icon">
         <option value="">None</option>
-        <option value="fa-bell">Bell</option>
-        <option value="fa-fire">Fire</option>
-        <option value="fa-exclamation-triangle">Warning</option>
-        <option value="fa-ambulance">Ambulance</option>
+        <option value="🔔">Bell</option>
+        <option value="🔥">Fire</option>
+        <option value="⚠️">Warning</option>
+        <option value="🚑">Ambulance</option>
       </select>
     </label>
-    <button type="submit"><i class="fas fa-plus"></i> Add</button>
+    <button type="submit" class="btn"><span class="icon">➕</span> Add</button>
   </form>
   <table id="buttons">
     <thead><tr><th>Name</th><th>Sound</th><th>Icon</th><th>Color</th><th>Actions</th></tr></thead>
@@ -58,13 +57,21 @@ async function loadButtons() {
   const data = await res.json();
   const tbody = document.querySelector('#buttons tbody');
   tbody.innerHTML = '';
+  const iconMap = {
+    'fa-bell': '🔔',
+    'fa-fire': '🔥',
+    'fa-exclamation-triangle': '⚠️',
+    'fa-ambulance': '🚑'
+  };
   data.forEach((btn, i) => {
     const tr = document.createElement('tr');
     const sound = audioMap[btn.sound_file] || btn.sound_file;
-    const iconHtml = btn.icon ? `<i class="fas ${btn.icon}"></i>` : '';
+    const icon = iconMap[btn.icon] || btn.icon || '';
+    const iconHtml = icon ? `<span class="icon">${icon}</span>` : '';
     tr.innerHTML = `<td>${btn.name}</td><td>${sound}</td><td>${iconHtml}</td><td><span style="background:${btn.color};padding:5px 10px;display:inline-block"></span></td>`;
     const del = document.createElement('button');
-    del.innerHTML = '<i class="fas fa-trash"></i> Delete';
+    del.className = 'btn';
+    del.innerHTML = '<span class="icon">🗑</span> Delete';
     del.onclick = async () => {
       await fetch('/api/buttons/' + i, { method: 'DELETE' });
       loadButtons();

--- a/static/index.html
+++ b/static/index.html
@@ -4,16 +4,15 @@
   <meta charset="UTF-8" />
   <title>PiBells Schedule</title>
   <link rel="stylesheet" href="/static/style.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
   <header>
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
     <div id="current-time"></div>
     <nav>
-      <a href="/admin"><i class="fas fa-cog"></i> Settings</a> |
-      <a href="/buttons"><i class="fas fa-bell"></i> Buttons</a> |
-      <a href="/logout"><i class="fas fa-sign-out-alt"></i> Logout</a>
+      <a href="/admin"><span class="icon">⚙️</span> Settings</a> |
+      <a href="/buttons"><span class="icon">🔔</span> Buttons</a> |
+      <a href="/logout"><span class="icon">🚪</span> Logout</a>
     </nav>
   </header>
   <div id="quick-buttons"></div>
@@ -22,9 +21,9 @@
     <label>Active schedule:
       <select id="schedule-select"></select>
     </label>
-    <button id="set-schedule"><i class="fas fa-check"></i> Set Schedule</button>
+    <button id="set-schedule" class="btn"><span class="icon">✔</span> Set Schedule</button>
     <input type="text" id="new-schedule" placeholder="New schedule">
-    <button id="add-schedule"><i class="fas fa-plus"></i> Add</button>
+    <button id="add-schedule" class="btn"><span class="icon">➕</span> Add</button>
   </div>
   <div id="schedule-grid" class="schedule-grid"></div>
   <script>
@@ -57,10 +56,17 @@ async function loadButtons() {
   const data = await res.json();
   const container = document.getElementById('quick-buttons');
   container.innerHTML = '';
+  const iconMap = {
+    'fa-bell': '🔔',
+    'fa-fire': '🔥',
+    'fa-exclamation-triangle': '⚠️',
+    'fa-ambulance': '🚑'
+  };
   data.forEach(btn => {
     const b = document.createElement('button');
-    if (btn.icon) {
-      b.innerHTML = `<i class="fas ${btn.icon}"></i> ${btn.name}`;
+    const icon = iconMap[btn.icon] || btn.icon || '';
+    if (icon) {
+      b.innerHTML = `<span class="icon">${icon}</span> ${btn.name}`;
     } else {
       b.textContent = btn.name;
     }
@@ -97,7 +103,8 @@ async function loadSchedule() {
           const timeDisp = formatTime12h(ev.time);
           li.textContent = `${timeDisp} - ${display}`;
           const btn = document.createElement('button');
-          btn.innerHTML = '<i class="fas fa-trash"></i> Remove';
+          btn.className = 'btn';
+          btn.innerHTML = '<span class="icon">🗑</span> Remove';
           btn.onclick = async () => {
             await fetch('/api/schedule/' + ev.index, { method: 'DELETE' });
             loadSchedule();
@@ -121,7 +128,8 @@ async function loadSchedule() {
     });
     const addBtn = document.createElement('button');
     addBtn.type = 'submit';
-    addBtn.innerHTML = '<i class="fas fa-plus"></i> Add';
+    addBtn.className = 'btn';
+    addBtn.innerHTML = '<span class="icon">➕</span> Add';
     form.appendChild(t);
     form.appendChild(sel);
     form.appendChild(addBtn);

--- a/static/login.html
+++ b/static/login.html
@@ -12,7 +12,7 @@
       <label>Username:<br><input type="text" name="username" required></label>
       <label>Password:<br><input type="password" name="password" required></label>
       <label class="remember"><input type="checkbox" name="remember"> Remember me</label>
-      <button type="submit">Login</button>
+      <button type="submit" class="btn">Login</button>
     </form>
     <div id="error-msg" style="color:red;"></div>
   </div>

--- a/static/style.css
+++ b/static/style.css
@@ -100,7 +100,7 @@ th {
 button {
   padding: 5px 10px;
 }
-button i {
+button .icon {
   margin-right: 4px;
 }
 form {
@@ -253,8 +253,8 @@ footer .footer-right {
   margin-bottom: 10px;
 }
 
-/* Settings page fancy buttons */
-.settings-page button {
+/* Reusable fancy button style */
+button.btn {
   border: none;
   padding: 8px 16px;
   border-radius: 20px;
@@ -263,8 +263,11 @@ footer .footer-right {
   cursor: pointer;
   box-shadow: 0 2px 5px rgba(0,0,0,0.3);
   transition: transform 0.1s ease-in-out;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 }
-.settings-page button:hover {
+button.btn:hover {
   transform: scale(1.05);
 }
 


### PR DESCRIPTION
## Summary
- remove Font Awesome dependency and use emoji icons
- create reusable `.btn` styles and apply across pages
- use emoji-based icons in quick button mapping

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685a391885888321a08869f1ac75f932