### PR TITLE
Fix button width on settings page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -279,6 +279,9 @@ button.btn {
   align-items: center;
   gap: 4px;
 }
+.settings-page button.btn {
+  width: auto;
+}
 button.btn:hover {
   transform: scale(1.05);
   box-shadow: 0 6px 14px rgba(0,0,0,0.3);


### PR DESCRIPTION
## Summary
- ensure buttons on the settings page are not full width

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685a40d546348321a14ad183587b32f0