### PR TITLE
Remove manual update check

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -52,7 +52,6 @@
 
   <h2>Software</h2>
   <p id="version-display"></p>
-  <button id="check-version" class="btn"><span class="icon">🔄</span> Check for Updates</button>
   <button id="update-btn" class="btn"><span class="icon">⬇️</span> Update</button>
   <button id="reboot-btn" class="btn"><span class="icon">⏻</span> Reboot</button>
   <div id="update-message" class="update-message" style="display:none;"></div>
@@ -232,7 +231,6 @@
     }
   }
 
-  document.getElementById('check-version').onclick = loadVersion;
 
   document.getElementById('update-btn').onclick = async () => {
     if (!confirm('Update PiBells now?')) return;
@@ -258,7 +256,7 @@
     await fetch('/api/reboot', { method: 'POST' });
   };
 
-  loadVersion();
+  document.addEventListener('DOMContentLoaded', loadVersion);
   function updateTime() {
     const now = new Date();
     const pad = n => n.toString().padStart(2, '0');


### PR DESCRIPTION
## Summary
- remove the **Check for updates** button from admin panel
- auto-check for updates when admin page loads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a45fc08b483218ff08e01b78b353b