### PR TITLE
Improve settings page headings

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -30,12 +30,14 @@
     <tbody></tbody>
   </table>
 
+  <hr class="section-divider">
   <h2>Network</h2>
   <div id="network-info" class="network-info">
     <span class="icon">🖧</span>
     <span id="hostname-display"></span> - <span id="ip-display"></span>
   </div>
 
+  <hr class="section-divider">
   <h2>Audio Files</h2>
   <form id="upload-form">
     <input type="file" id="audio-file" accept="audio/*" required>
@@ -44,12 +46,14 @@
   </form>
   <div id="audio-list" class="audio-grid"></div>
 
+  <hr class="section-divider">
   <h2>Test</h2>
   <div class="test-section">
     <label>Sound file: <select id="test-sound"></select></label>
     <button id="test-play" class="btn"><span class="icon">▶️</span> Play</button>
   </div>
 
+  <hr class="section-divider">
   <h2>Software</h2>
   <p id="version-display"></p>
   <button id="update-btn" class="btn"><span class="icon">⬇️</span> Update</button>

--- a/static/style.css
+++ b/static/style.css
@@ -349,6 +349,20 @@ button.btn {
 .settings-page button.btn {
   width: auto;
 }
+
+/* Match heading styles on settings page */
+.settings-page h1,
+.settings-page h2 {
+  font-size: 1.4em;
+  margin-top: 30px;
+  margin-bottom: 10px;
+}
+
+.section-divider {
+  border: none;
+  border-top: 1px solid var(--table-border);
+  margin: 30px 0;
+}
 button.btn:hover {
   transform: scale(1.05);
   box-shadow: 0 6px 14px rgba(0,0,0,0.3);


### PR DESCRIPTION
## Summary
- unify heading font sizes across settings page
- add section divider styling
- insert section dividers in admin page

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a46c3345883218334216094f401be