### PR TITLE
Fix remove button alignment on schedule

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -145,6 +145,7 @@ table {
 .schedule-day li {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   margin: 4px 0;
 }
 th, td {


### PR DESCRIPTION
## Summary
- align buttons with event text on the schedule list

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685a47ced95083219f707cb246ddc0ce