### PR TITLE
Fix audio list button spacing

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -210,8 +210,12 @@ form {
   border-radius: 8px;
   box-shadow: 0 2px 5px rgba(0,0,0,0.3);
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 4px;
+}
+
+.audio-item span {
+  flex: 1;
 }
 
 .test-section {


### PR DESCRIPTION
## Summary
- tweak audio item layout so edit/delete buttons sit closer together

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a488aeaf08321b3d764457bca1f7e