### PR TITLE
Fix rendering for network and reboot icons

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -33,7 +33,7 @@
   <hr class="section-divider">
   <h2>Network</h2>
   <div id="network-info" class="network-info">
-    <span class="icon">🖧</span>
+    <span class="icon">🌐</span>
     <span id="hostname-display"></span> - <span id="ip-display"></span>
   </div>
 
@@ -57,7 +57,7 @@
   <h2>Software</h2>
   <p id="version-display"></p>
   <button id="update-btn" class="btn"><span class="icon">⬇️</span> Update</button>
-  <button id="reboot-btn" class="btn"><span class="icon">⏻</span> Reboot</button>
+  <button id="reboot-btn" class="btn"><span class="icon">🔌</span> Reboot</button>
   <div id="update-message" class="update-message" style="display:none;"></div>
   <script>
   async function loadNetwork() {


### PR DESCRIPTION
## Summary
- use more common emoji for the network and reboot icons on the settings page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a4993b2188321a0a2ba195c780d6a