### PR TITLE
Stream audio via TCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PiBells is a lightweight bell scheduler built with FastAPI. It turns a Raspberry
 
 ## Features
 - 📅 Create multiple schedules from your browser
-- 🔊 Trigger Barix devices or play audio locally
+- 🔊 Stream bells to Barix devices over port 2020 or play audio locally
 - 🌐 Scan your network to discover devices automatically
 - 🎵 Upload MP3, WAV, OGG or M4A files as bell sounds
 - 🗑 Delete old audio files to free up space

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ fi
 
 apt-get update
 apt-get upgrade -y
-apt-get install -y python3 python3-pip python3-venv git nginx neofetch ffmpeg alsa-utils
+apt-get install -y python3 python3-pip python3-venv git nginx neofetch ffmpeg alsa-utils netcat-openbsd
 
 TARGET_USER=${SUDO_USER:-pibells}
 HOME_DIR=$(eval echo "~$TARGET_USER")


### PR DESCRIPTION
## Summary
- stream bells to Barix devices via TCP port 2020 using ffmpeg and nc
- install `netcat-openbsd` to provide `nc`
- update README to mention streaming method

## Testing
- `python3 -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_685b22c9ebe48321b2b710b7236e4880