### PR TITLE
Add PWA support

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -663,3 +663,13 @@ def admin():
 @app.get("/buttons")
 def buttons_page():
     return FileResponse("static/buttons.html")
+
+@app.get("/manifest.json")
+def manifest_file():
+    return FileResponse("static/manifest.json")
+
+
+@app.get("/service-worker.js")
+def service_worker():
+    return FileResponse("static/service-worker.js", media_type="application/javascript")
+

--- a/static/admin.html
+++ b/static/admin.html
@@ -2,6 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="/manifest.json">
+  <link rel="apple-touch-icon" href="/static/icons/icon-192.png">
+  <meta name="theme-color" content="#4facfe">
   <title>Device Configuration</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>

--- a/static/buttons.html
+++ b/static/buttons.html
@@ -2,6 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="/manifest.json">
+  <link rel="apple-touch-icon" href="/static/icons/icon-192.png">
+  <meta name="theme-color" content="#4facfe">
   <title>Button Configuration</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>

--- a/static/index.html
+++ b/static/index.html
@@ -2,6 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="/manifest.json">
+  <link rel="apple-touch-icon" href="/static/icons/icon-192.png">
+  <meta name="theme-color" content="#4facfe">
   <title>PiBells Schedule</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>

--- a/static/login.html
+++ b/static/login.html
@@ -2,6 +2,10 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="/manifest.json">
+  <link rel="apple-touch-icon" href="/static/icons/icon-192.png">
+  <meta name="theme-color" content="#4facfe">
   <title>Login - PiBells</title>
   <link rel="stylesheet" href="/static/style.css">
 </head>

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "PiBells",
+  "short_name": "PiBells",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#4facfe",
+  "icons": [
+    {
+      "src": "/static/icons/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/static/icons/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,0 +1,22 @@
+const CACHE_NAME = 'pibells-cache-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/static/style.css',
+  '/static/theme.js',
+  '/static/pibells-logo.png',
+  '/static/smallroundlogo.png',
+  '/static/icons/icon-192.png',
+  '/static/icons/icon-512.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/static/theme.js
+++ b/static/theme.js
@@ -40,3 +40,9 @@ function initTheme() {
 }
 
 document.addEventListener('DOMContentLoaded', initTheme);
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js');
+  });
+}


### PR DESCRIPTION
## Summary
- add manifest with icons for PWA install
- create service worker for offline caching
- register service worker in theme.js
- serve manifest and service worker via FastAPI
- include manifest and theme color meta tags in HTML pages

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685b27933de48321b2239c8283c06823