### PR TITLE
Fix settings page button width

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -367,8 +367,10 @@ button.btn {
 .btn.btn-danger {
   background: linear-gradient(45deg, #ff4b5c, #e02424);
 }
-.settings-page button.btn {
+.settings-page button {
   width: auto;
+  display: inline-flex;
+  align-items: center;
 }
 
 /* Match heading styles on settings page */


### PR DESCRIPTION
## Summary
- ensure that buttons on the settings page never stretch full width

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b293b1f8483218572d244c6913244