### PR TITLE
Fix login form sizing

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -324,7 +324,7 @@ footer .footer-right {
 }
 
 .login-container {
-  max-width: 300px;
+  max-width: 360px;
   margin: 100px auto;
   background: var(--table-bg);
   padding: 30px;
@@ -342,6 +342,7 @@ footer .footer-right {
 .login-container input[type="password"] {
   width: 100%;
   padding: 12px;
+  box-sizing: border-box;
 }
 
 .login-logo {


### PR DESCRIPTION
## Summary
- widen the login box
- prevent text fields from overflowing their container

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b2a53be588321be537c71b5fbccda