### PR TITLE
Simplify navigation menu

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -14,9 +14,6 @@
   <header>
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
     <div id="current-time"></div>
-    <button id="menu-toggle" class="hamburger" aria-label="Menu">
-      <span></span><span></span><span></span>
-    </button>
     <nav>
       <a href="/"><span class="icon"><i class="fa-solid fa-arrow-left"></i></span> Back to Schedule</a>
       <a href="/logout"><span class="icon"><i class="fa-solid fa-right-from-bracket"></i></span> Logout</a>

--- a/static/buttons.html
+++ b/static/buttons.html
@@ -14,9 +14,6 @@
   <header>
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
     <div id="current-time"></div>
-    <button id="menu-toggle" class="hamburger" aria-label="Menu">
-      <span></span><span></span><span></span>
-    </button>
     <nav>
       <a href="/"><span class="icon"><i class="fa-solid fa-arrow-left"></i></span> Back to Schedule</a>
       <a href="/logout"><span class="icon"><i class="fa-solid fa-right-from-bracket"></i></span> Logout</a>

--- a/static/index.html
+++ b/static/index.html
@@ -14,9 +14,6 @@
   <header>
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
     <div id="current-time"></div>
-    <button id="menu-toggle" class="hamburger" aria-label="Menu">
-      <span></span><span></span><span></span>
-    </button>
     <nav>
       <a href="/admin"><span class="icon"><i class="fa-solid fa-gear"></i></span> Settings</a>
       <a href="/buttons"><span class="icon"><i class="fa-solid fa-bell"></i></span> Buttons</a>

--- a/static/style.css
+++ b/static/style.css
@@ -58,55 +58,9 @@ header {
 }
 
 header nav {
-  display: none;
-  flex-direction: column;
-  gap: 14px;
-  position: absolute;
-  top: 60px;
-  right: 20px;
-  background: var(--table-bg);
-  padding: 10px;
-  border-radius: 8px;
-  box-shadow: 0 2px 5px rgba(0,0,0,0.3);
-  z-index: 1000;
-}
-
-header nav.open {
   display: flex;
-}
-
-#menu-toggle {
+  gap: 14px;
   margin-left: auto;
-  width: 40px;
-  height: 30px;
-  position: relative;
-  border: none;
-  background: none;
-  cursor: pointer;
-}
-
-#menu-toggle span {
-  position: absolute;
-  left: 0;
-  width: 100%;
-  height: 3px;
-  background: linear-gradient(45deg, var(--accent-start), var(--accent-end));
-  border-radius: 2px;
-  transition: transform 0.3s, opacity 0.3s;
-}
-
-#menu-toggle span:nth-child(1) { top: 0; }
-#menu-toggle span:nth-child(2) { top: 9px; }
-#menu-toggle span:nth-child(3) { top: 18px; }
-
-#menu-toggle.open span:nth-child(1) {
-  transform: translateY(9px) rotate(45deg);
-}
-#menu-toggle.open span:nth-child(2) {
-  opacity: 0;
-}
-#menu-toggle.open span:nth-child(3) {
-  transform: translateY(-9px) rotate(-45deg);
 }
 header img.logo {
   height: 60px;

--- a/static/theme.js
+++ b/static/theme.js
@@ -29,14 +29,6 @@ function initTheme() {
     if (localStorage.getItem('theme') === 'auto') applyTheme('auto');
   });
 
-  const toggle = document.getElementById('menu-toggle');
-  const nav = document.querySelector('header nav');
-  if (toggle && nav) {
-    toggle.addEventListener('click', () => {
-      nav.classList.toggle('open');
-      toggle.classList.toggle('open');
-    });
-  }
 }
 
 document.addEventListener('DOMContentLoaded', initTheme);


### PR DESCRIPTION
## Summary
- remove hamburger button from each page
- always show the nav items inline
- drop JS for toggling the menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b569dfd508321aaa2e557c4bcbae9