### PR TITLE
Reduce brightness of light theme background

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -11,7 +11,7 @@
   --footer-text: #fff;
   --accent-start: #4facfe;
   --accent-end: #00f2fe;
-  --bg-overlay: rgba(255,255,255,0.5);
+  --bg-overlay: rgba(255,255,255,0.75);
 }
 
 body {


### PR DESCRIPTION
## Summary
- increase white overlay opacity for the light theme background

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b58f7abe0832198951c9375d6dce9