### PR TITLE
Fix width of scan and update buttons

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -349,6 +349,7 @@ button.btn {
   width: auto;
   display: inline-flex;
   align-items: center;
+  align-self: flex-start;
 }
 
 /* Match heading styles on settings page */


### PR DESCRIPTION
## Summary
- ensure settings page buttons don't stretch to full width

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685b5a7988048321875df496815b2a48