### PR TITLE
Fix color input size

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -134,6 +134,10 @@ form select {
   font-size: 1em;
   margin: 4px 8px 4px 0;
 }
+form input[type="color"] {
+  width: 150px;
+  height: 40px;
+}
 #icon-preview i {
   font-size: 1.2em;
 }


### PR DESCRIPTION
## Summary
- ensure color picker matches select box size on Quick Buttons page

## Testing
- `grep -n "input[type="color"]" -n static/style.css`

------
https://chatgpt.com/codex/tasks/task_e_685b6f2cf68c8321a809bc9de79c2d9d