### PR TITLE
Fix netcat termination

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -268,7 +268,8 @@ def trigger_bell(sound_file: str):
             "mp3",
             "-",
         ]
-        nc_cmd = ["nc", device, "2020"]
+        # Use -q 0 so nc quits immediately once stdin closes
+        nc_cmd = ["nc", "-q", "0", device, "2020"]
         try:
             ffmpeg_proc = subprocess.Popen(
                 ffmpeg_cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL


### PR DESCRIPTION
## Summary
- ensure netcat exits when ffmpeg closes by using `-q 0`

## Testing
- `python3 -m py_compile app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b71d43a208321bb2418324df65fc7