### PR TITLE
Fix theme button alignment on settings page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -353,7 +353,7 @@ button.btn {
 .btn.btn-danger {
   background: linear-gradient(45deg, #ff4b5c, #e02424);
 }
-.settings-page button {
+.settings-page button:not(.theme-btn) {
   width: auto;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- ensure settings page styles don't override theme button layout

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b74d6de8c8321920e3741439fbba5