### PR TITLE
Improve audio tile layout in settings

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -140,9 +140,19 @@
     data.forEach(file => {
       const div = document.createElement('div');
       div.className = 'audio-item';
-      const span = document.createElement('span');
-      span.textContent = file.name;
-      div.appendChild(span);
+
+      const name = document.createElement('div');
+      name.className = 'audio-name';
+      name.textContent = file.name;
+      div.appendChild(name);
+
+      const icon = document.createElement('i');
+      icon.className = 'fa-solid fa-music audio-icon';
+      div.appendChild(icon);
+
+      const actions = document.createElement('div');
+      actions.className = 'audio-actions';
+
       const testBtn = document.createElement('button');
       testBtn.className = 'btn';
       testBtn.innerHTML = '<span class="icon"><i class="fa-solid fa-play"></i></span> Test';
@@ -153,7 +163,8 @@
           body: JSON.stringify({ sound_file: file.file })
         });
       };
-      div.appendChild(testBtn);
+      actions.appendChild(testBtn);
+
       const edit = document.createElement('button');
       edit.className = 'btn';
       edit.innerHTML = '<span class="icon"><i class="fa-solid fa-pen"></i></span> Rename';
@@ -167,7 +178,8 @@
         });
         loadAudio();
       };
-      div.appendChild(edit);
+      actions.appendChild(edit);
+
       const del = document.createElement('button');
       del.className = 'btn btn-danger';
       del.innerHTML = '<span class="icon"><i class="fa-solid fa-trash"></i></span> Delete';
@@ -176,7 +188,9 @@
         await fetch('/api/audio/' + encodeURIComponent(file.file), { method: 'DELETE' });
         loadAudio();
       };
-      div.appendChild(del);
+      actions.appendChild(del);
+
+      div.appendChild(actions);
       list.appendChild(div);
     });
   }

--- a/static/style.css
+++ b/static/style.css
@@ -199,7 +199,7 @@ form input[type="color"] {
 
 .audio-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 15px;
   margin-top: 15px;
 }
@@ -210,12 +210,26 @@ form input[type="color"] {
   border-radius: 8px;
   box-shadow: 0 2px 5px rgba(0,0,0,0.3);
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 4px;
+  text-align: center;
+  min-height: 200px;
 }
 
-.audio-item span {
-  flex: 1;
+.audio-name {
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.audio-icon {
+  font-size: 48px;
+  margin-bottom: 10px;
+}
+
+.audio-actions {
+  margin-top: auto;
+  display: flex;
+  gap: 6px;
 }
 
 .test-section {


### PR DESCRIPTION
## Summary
- redesign audio item grid tiles
- make audio buttons appear at the bottom of each tile with a large music icon

## Testing
- `python -m py_compile app/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b75fe3b388321a0aa58ee696ac290