### PR TITLE
Allow network endpoint without auth

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -49,7 +49,13 @@ def authenticate_user(username: str, password: str) -> bool:
 @app.middleware("http")
 async def auth_middleware(request: Request, call_next):
     path = request.url.path
-    if path.startswith("/static") or path.startswith("/audio") or path == "/login" or path == "/logout":
+    if (
+        path.startswith("/static")
+        or path.startswith("/audio")
+        or path == "/login"
+        or path == "/logout"
+        or path == "/api/network"
+    ):
         return await call_next(request)
     token = request.cookies.get("session")
     if not token or token not in sessions:


### PR DESCRIPTION
## Summary
- allow `/api/network` to be accessed without authentication so the login page can show hostname and IP

## Testing
- `python3 -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685b77bf599c83218976e8cd73cc965e