### PR TITLE
Fix Reboot button alignment

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -44,9 +44,11 @@
   <hr class="section-divider">
   <h2>Software</h2>
   <p id="version-display"></p>
-  <button id="update-btn" class="btn"><span class="icon"><i class="fa-solid fa-download"></i></span> Update</button>
-  <button id="reboot-btn" class="btn"><span class="icon"><i class="fa-solid fa-plug"></i></span> Reboot</button>
-  <div id="update-message" class="update-message" style="display:none;"></div>
+  <div class="update-actions">
+    <button id="update-btn" class="btn"><span class="icon"><i class="fa-solid fa-download"></i></span> Update</button>
+    <button id="reboot-btn" class="btn"><span class="icon"><i class="fa-solid fa-plug"></i></span> Reboot</button>
+    <div id="update-message" class="update-message" style="display:none;"></div>
+  </div>
   <script>
   async function loadDevices() {
     const res = await fetch('/api/devices');

--- a/static/style.css
+++ b/static/style.css
@@ -405,6 +405,12 @@ button.btn:hover {
   gap: 5px;
 }
 
+.update-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
 @keyframes fade-in {
   from { opacity: 0; }
   to { opacity: 1; }


### PR DESCRIPTION
## Summary
- group the reboot and update controls
- style group as inline-flex so both buttons sit next to each other

## Testing
- `python3 -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685b7b6b53908321b244191eee5dc159