### PR TITLE
Improve audio file card layout

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -226,14 +226,17 @@ form input[type="color"] {
   flex-direction: column;
   align-items: center;
   text-align: center;
-  min-height: 150px;
+  min-height: 120px;
 }
 
 .audio-name {
   font-weight: bold;
-  font-size: 1.2em;
+  font-size: 1.4em;
   display: flex;
   align-items: center;
+  justify-content: center;
+  text-align: center;
+  width: 100%;
   gap: 6px;
   margin-bottom: 6px;
 }


### PR DESCRIPTION
## Summary
- shrink unused space in audio file cards
- enlarge and center audio file name text

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b8470ae0c8321bbdbf1de2e4350d7