### PR TITLE
Improve audio upload layout

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -33,11 +33,14 @@
 
   <hr class="section-divider">
   <h2>Audio Files</h2>
-  <form id="upload-form">
-    <input type="file" id="audio-file" accept="audio/*" required>
-    <input type="text" id="audio-name" placeholder="Name" required>
-    <button type="submit" class="btn"><span class="icon"><i class="fa-solid fa-upload"></i></span> Upload</button>
-  </form>
+  <div class="upload-box">
+    <h3>Add New File</h3>
+    <form id="upload-form">
+      <input type="file" id="audio-file" accept="audio/*" required>
+      <input type="text" id="audio-name" placeholder="Name" required>
+      <button type="submit" class="btn"><span class="icon"><i class="fa-solid fa-upload"></i></span> Upload</button>
+    </form>
+  </div>
   <div id="audio-list" class="audio-grid"></div>
 
 

--- a/static/style.css
+++ b/static/style.css
@@ -342,6 +342,15 @@ footer .footer-right {
   margin-top: 15px;
 }
 
+/* Container for uploading new audio files */
+.upload-box {
+  background: var(--table-bg);
+  padding: 15px;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+  margin-bottom: 15px;
+}
+
 .login-container {
   max-width: 360px;
   margin: 100px auto;


### PR DESCRIPTION
## Summary
- show "Add New File" heading on audio uploads
- wrap uploads in a styled box for clarity

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b858429d88321b7181d8922ab2369