### PR TITLE
Switch to UDP streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ PiBells is a lightweight bell scheduler built with FastAPI. It turns a Raspberry
 
 ## Features
 - 📅 Create multiple schedules from your browser
-- 🔊 Stream bells to Barix devices over port 2020 or play audio locally
+- 🔊 Stream bells to Barix devices using UDP on port 3020 or play audio locally
 - 🌐 Scan your network to discover devices automatically
 - 🎵 Upload MP3, WAV, OGG or M4A files as bell sounds
 - 🗑 Delete old audio files to free up space

--- a/app/main.py
+++ b/app/main.py
@@ -254,28 +254,31 @@ def trigger_bell(sound_file: str):
     def send(device: str):
         ffmpeg_cmd = [
             "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
             "-re",
+            "-fflags",
+            "+nobuffer",
+            "-flush_packets",
+            "1",
             "-i",
             str(path),
             "-f",
             "mp3",
-            "-",
+            "-codec:a",
+            "libmp3lame",
+            "-b:a",
+            "128k",
+            f"udp://{device}:3020",
         ]
-        # Use -q 0 so nc quits immediately once stdin closes
-        nc_cmd = ["nc", "-q", "0", device, "2020"]
         try:
-            ffmpeg_proc = subprocess.Popen(
-                ffmpeg_cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
-            )
-            nc_proc = subprocess.Popen(
-                nc_cmd,
-                stdin=ffmpeg_proc.stdout,
+            subprocess.run(
+                ffmpeg_cmd,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                check=True,
             )
-            ffmpeg_proc.stdout.close()
-            nc_proc.communicate()
-            ffmpeg_proc.wait()
         except FileNotFoundError as e:
             print(f"Failed to stream to {device}: {e}")
 


### PR DESCRIPTION
## Summary
- stream audio to Barix devices over UDP instead of TCP
- document new UDP port in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b8a1b79948321880d8c706e06c5bf