### PR TITLE
Add rebooting page and redirect

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -54,6 +54,7 @@ async def auth_middleware(request: Request, call_next):
         or path == "/login"
         or path == "/logout"
         or path == "/api/network"
+        or path == "/rebooting"
     ):
         return await call_next(request)
     token = request.cookies.get("session")
@@ -677,3 +678,8 @@ def manifest_file():
 @app.get("/service-worker.js")
 def service_worker():
     return FileResponse("static/service-worker.js", media_type="application/javascript")
+
+
+@app.get("/rebooting")
+def rebooting_page():
+    return FileResponse("static/rebooting.html")

--- a/static/admin.html
+++ b/static/admin.html
@@ -249,6 +249,7 @@
   document.getElementById('reboot-btn').onclick = async () => {
     if (!confirm('Reboot the device now?')) return;
     await fetch('/api/reboot', { method: 'POST' });
+    window.location.href = '/rebooting';
   };
 
   document.addEventListener('DOMContentLoaded', loadVersion);

--- a/static/rebooting.html
+++ b/static/rebooting.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="manifest" href="/manifest.json">
+  <link rel="apple-touch-icon" href="/static/icons/icon-192.png">
+  <meta name="theme-color" content="#4facfe">
+  <title>Rebooting - PiBells</title>
+  <link rel="stylesheet" href="/static/style.css">
+  <link rel="stylesheet" href="/static/css/all.min.css">
+</head>
+<body>
+  <div class="login-container">
+    <img src="/static/pibells-logo.png" alt="PiBells logo" class="login-logo" />
+    <div style="margin:20px 0;">
+      <i class="fa-solid fa-spinner fa-spin fa-3x"></i>
+    </div>
+    <p>Rebooting, please wait...</p>
+  </div>
+  <script src="/static/theme.js"></script>
+  <script>
+    setTimeout(() => {
+      location.replace('/login');
+    }, 60000);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show new rebooting page during system restart
- allow access to `/rebooting` without login
- redirect admin page to rebooting page after requesting reboot

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685cbc7dcf1c8321bee15e6d96833799