### PR TITLE
Improve quick play button feedback

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -159,12 +159,20 @@
       testBtn.className = 'icon-btn test-icon';
       testBtn.title = 'Test';
       testBtn.innerHTML = '<i class="fa-solid fa-play"></i>';
+      const original = testBtn.innerHTML;
       testBtn.onclick = async () => {
-        await fetch('/api/test', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sound_file: file.file })
-        });
+        testBtn.innerHTML = '<i class="fa-solid fa-stop"></i>';
+        testBtn.disabled = true;
+        try {
+          await fetch('/api/test', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sound_file: file.file })
+          });
+        } finally {
+          testBtn.innerHTML = original;
+          testBtn.disabled = false;
+        }
       };
       actions.appendChild(testBtn);
 

--- a/static/index.html
+++ b/static/index.html
@@ -70,12 +70,20 @@ async function loadButtons() {
       b.textContent = btn.name;
     }
     b.style.background = btn.color;
+    const original = b.innerHTML;
     b.onclick = async () => {
-      await fetch('/api/test', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sound_file: btn.sound_file })
-      });
+      b.innerHTML = `<span class="icon"><i class="fa-solid fa-stop"></i></span> ${btn.name}`;
+      b.disabled = true;
+      try {
+        await fetch('/api/test', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ sound_file: btn.sound_file })
+        });
+      } finally {
+        b.innerHTML = original;
+        b.disabled = false;
+      }
     };
     container.appendChild(b);
   });


### PR DESCRIPTION
## Summary
- show a stop icon on quick buttons while audio plays
- update test buttons in admin page to swap play/stop icons

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685cbfbb6b248321b40e9fcb74d59715