### PR TITLE
Add looping playback option for quick buttons

### DIFF
--- a/static/buttons.html
+++ b/static/buttons.html
@@ -38,6 +38,7 @@
       </select>
       <span id="icon-preview" class="icon"></span>
     </label>
+    <label><input type="checkbox" id="loop"> Loop until stopped</label>
     <button type="submit" class="btn"><span class="icon"><i class="fa-solid fa-plus"></i></span> Add</button>
   </form>
   <div id="buttons" class="button-grid"></div>
@@ -92,7 +93,7 @@ async function loadButtons() {
     const info = document.createElement('div');
     info.className = 'button-info';
     const sound = audioMap[btn.sound_file] || btn.sound_file;
-    info.textContent = sound;
+    info.textContent = btn.loop ? sound + ' (loop)' : sound;
     item.appendChild(info);
 
     const colorBox = document.createElement('div');
@@ -122,10 +123,11 @@ document.getElementById('add-form').onsubmit = async (e) => {
   const sound = document.getElementById('sound').value;
   const color = document.getElementById('color').value;
   const icon = document.getElementById('icon').value;
+  const loop = document.getElementById('loop').checked;
   await fetch('/api/buttons', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, sound_file: sound, color, icon })
+    body: JSON.stringify({ name, sound_file: sound, color, icon, loop })
   });
   e.target.reset();
   loadButtons();

--- a/static/index.html
+++ b/static/index.html
@@ -61,6 +61,7 @@ async function loadButtons() {
     'fa-school': '<i class="fa-solid fa-school"></i>',
     'fa-music': '<i class="fa-solid fa-music"></i>'
   };
+  let playing = null;
   data.forEach(btn => {
     const b = document.createElement('button');
     const icon = iconMap[btn.icon] || btn.icon || '';
@@ -70,19 +71,39 @@ async function loadButtons() {
       b.textContent = btn.name;
     }
     b.style.background = btn.color;
-    const original = b.innerHTML;
+    b.dataset.original = b.innerHTML;
     b.onclick = async () => {
-      b.innerHTML = `<span class="icon"><i class="fa-solid fa-stop"></i></span> ${btn.name}`;
-      b.disabled = true;
-      try {
+      if (btn.loop) {
+        if (playing === b) {
+          await fetch('/api/stop', { method: 'POST' });
+          b.innerHTML = b.dataset.original;
+          playing = null;
+          return;
+        }
+        if (playing) {
+          await fetch('/api/stop', { method: 'POST' });
+          playing.innerHTML = playing.dataset.original;
+        }
+        b.innerHTML = `<span class="icon"><i class="fa-solid fa-stop"></i></span> ${btn.name}`;
+        playing = b;
         await fetch('/api/test', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ sound_file: btn.sound_file })
+          body: JSON.stringify({ sound_file: btn.sound_file, loop: true })
         });
-      } finally {
-        b.innerHTML = original;
-        b.disabled = false;
+      } else {
+        b.innerHTML = `<span class="icon"><i class="fa-solid fa-stop"></i></span> ${btn.name}`;
+        b.disabled = true;
+        try {
+          await fetch('/api/test', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sound_file: btn.sound_file })
+          });
+        } finally {
+          b.innerHTML = b.dataset.original;
+          b.disabled = false;
+        }
       }
     };
     container.appendChild(b);


### PR DESCRIPTION
## Summary
- allow Quick Play buttons to loop playback
- show loop option when creating buttons
- update schedule page to toggle looping sounds
- add API endpoint to stop looping playback

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685cc14a761c83219e35889e1e43e259