### PR TITLE
Add mobile responsive layout

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -14,6 +14,7 @@
   <header>
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
     <div id="current-time"></div>
+    <button id="menu-toggle" class="hamburger"><i class="fa-solid fa-bars"></i></button>
     <nav>
       <a href="/"><span class="icon"><i class="fa-solid fa-arrow-left"></i></span> Back to Schedule</a>
       <a href="/logout"><span class="icon"><i class="fa-solid fa-right-from-bracket"></i></span> Logout</a>

--- a/static/buttons.html
+++ b/static/buttons.html
@@ -14,6 +14,7 @@
   <header>
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
     <div id="current-time"></div>
+    <button id="menu-toggle" class="hamburger"><i class="fa-solid fa-bars"></i></button>
     <nav>
       <a href="/"><span class="icon"><i class="fa-solid fa-arrow-left"></i></span> Back to Schedule</a>
       <a href="/logout"><span class="icon"><i class="fa-solid fa-right-from-bracket"></i></span> Logout</a>

--- a/static/index.html
+++ b/static/index.html
@@ -14,6 +14,7 @@
   <header>
     <img src="/static/pibells-logo.png" alt="PiBells logo" class="logo" />
     <div id="current-time"></div>
+    <button id="menu-toggle" class="hamburger"><i class="fa-solid fa-bars"></i></button>
     <nav>
       <a href="/admin"><span class="icon"><i class="fa-solid fa-gear"></i></span> Settings</a>
       <a href="/buttons"><span class="icon"><i class="fa-solid fa-bell"></i></span> Buttons</a>

--- a/static/style.css
+++ b/static/style.css
@@ -62,6 +62,14 @@ header nav {
   gap: 14px;
   margin-left: auto;
 }
+button.hamburger {
+  display: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1.8em;
+  margin-left: auto;
+}
 header img.logo {
   height: 60px;
 }
@@ -517,4 +525,34 @@ button.btn:hover {
 
 body.theme-transition {
   animation: fade-in 0.5s ease;
+}
+
+@media (max-width: 700px) {
+  header nav {
+    display: none;
+    flex-direction: column;
+    position: absolute;
+    top: 60px;
+    right: 20px;
+    background: var(--header-bg);
+    padding: 10px;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+    z-index: 10;
+  }
+  header nav.show {
+    display: flex;
+  }
+  button.hamburger {
+    display: block;
+  }
+  header img.logo {
+    height: 40px;
+  }
+  #current-time {
+    font-size: 2em;
+  }
+  body {
+    padding: 10px;
+  }
 }

--- a/static/theme.js
+++ b/static/theme.js
@@ -31,7 +31,20 @@ function initTheme() {
 
 }
 
-document.addEventListener('DOMContentLoaded', initTheme);
+function initMenu() {
+  const toggle = document.getElementById('menu-toggle');
+  const nav = document.querySelector('header nav');
+  if (toggle && nav) {
+    toggle.addEventListener('click', () => {
+      nav.classList.toggle('show');
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initTheme();
+  initMenu();
+});
 
 if ('serviceWorker' in navigator) {
   window.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- implement responsive styling with media query
- add hamburger menu toggle for small screens
- shrink clock display on mobile
- update pages to include mobile nav button

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685cc38bcad48321b84a1a514f0f268a