### PR TITLE
Use icon for loop indicator

### DIFF
--- a/static/buttons.html
+++ b/static/buttons.html
@@ -94,7 +94,11 @@ async function loadButtons() {
     const info = document.createElement('div');
     info.className = 'button-info';
     const sound = audioMap[btn.sound_file] || btn.sound_file;
-    info.textContent = btn.loop ? sound + ' (loop)' : sound;
+    if (btn.loop) {
+      info.innerHTML = `${sound} <i class="fa-solid fa-repeat" title="Loops"></i>`;
+    } else {
+      info.textContent = sound;
+    }
     item.appendChild(info);
 
     const colorBox = document.createElement('div');


### PR DESCRIPTION
## Summary
- show a repeat icon instead of '(loop)' text on the Buttons page

## Testing
- `python -m py_compile app/*.py`
- `shellcheck install.sh` *(fails: command not found)*
- `flake8 app` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cc670539083219941a2c64c225126