### PR TITLE
Fix hamburger visibility on settings page

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -448,7 +448,7 @@ button.btn {
 .btn.btn-danger {
   background: linear-gradient(45deg, #ff4b5c, #e02424);
 }
-.settings-page button:not(.theme-btn) {
+.settings-page button:not(.theme-btn):not(.hamburger) {
   width: auto;
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- adjust CSS so the hamburger icon is hidden on larger screens

## Testing
- `python -m py_compile app/__init__.py app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685cc73a8e6c8321836934544ad692c3