### PR TITLE
Enhance mobile menu icons

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -62,6 +62,14 @@ header nav {
   gap: 14px;
   margin-left: auto;
 }
+header nav a {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+header nav a .icon {
+  margin-right: 4px;
+}
 button.hamburger {
   display: none;
   background: none;
@@ -539,6 +547,15 @@ body.theme-transition {
     border-radius: 8px;
     box-shadow: 0 2px 5px rgba(0,0,0,0.3);
     z-index: 10;
+  }
+  header nav a {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+  header nav a .icon {
+    margin: 0 0 4px;
+    font-size: 1.6em;
   }
   header nav.show {
     display: flex;


### PR DESCRIPTION
## Summary
- style header nav links for normal view
- stack menu text under icons in mobile view and enlarge icons

## Testing
- `python3 -m compileall app`

------
https://chatgpt.com/codex/tasks/task_e_685cd1bbefe48321b8ada6335a41c0eb