### PR TITLE
Add mobile split for header clock

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -270,8 +270,14 @@
     const ampm = hours >= 12 ? 'PM' : 'AM';
     hours = hours % 12;
     if (hours === 0) hours = 12;
-    const str = `${days[now.getDay()]} ${pad(hours)}:${pad(now.getMinutes())}:${pad(now.getSeconds())} ${ampm}`;
-    document.getElementById('current-time').textContent = str;
+    const dayStr = days[now.getDay()];
+    const timeStr = `${pad(hours)}:${pad(now.getMinutes())}:${pad(now.getSeconds())} ${ampm}`;
+    const el = document.getElementById('current-time');
+    if (window.matchMedia('(max-width: 700px)').matches) {
+      el.innerHTML = `${dayStr}<br>${timeStr}`;
+    } else {
+      el.textContent = `${dayStr} ${timeStr}`;
+    }
   }
   updateTime();
   setInterval(updateTime, 1000);

--- a/static/buttons.html
+++ b/static/buttons.html
@@ -154,8 +154,14 @@ document.getElementById('add-form').onsubmit = async (e) => {
     const ampm = hours >= 12 ? 'PM' : 'AM';
     hours = hours % 12;
     if (hours === 0) hours = 12;
-    const str = `${days[now.getDay()]} ${pad(hours)}:${pad(now.getMinutes())}:${pad(now.getSeconds())} ${ampm}`;
-    document.getElementById('current-time').textContent = str;
+    const dayStr = days[now.getDay()];
+    const timeStr = `${pad(hours)}:${pad(now.getMinutes())}:${pad(now.getSeconds())} ${ampm}`;
+    const el = document.getElementById('current-time');
+    if (window.matchMedia('(max-width: 700px)').matches) {
+      el.innerHTML = `${dayStr}<br>${timeStr}`;
+    } else {
+      el.textContent = `${dayStr} ${timeStr}`;
+    }
   }
   updateTime();
   setInterval(updateTime, 1000);

--- a/static/index.html
+++ b/static/index.html
@@ -234,8 +234,14 @@ function updateTime() {
   const ampm = hours >= 12 ? 'PM' : 'AM';
   hours = hours % 12;
   if (hours === 0) hours = 12;
-  const str = `${days[now.getDay()]} ${pad(hours)}:${pad(now.getMinutes())}:${pad(now.getSeconds())} ${ampm}`;
-  document.getElementById('current-time').textContent = str;
+  const dayStr = days[now.getDay()];
+  const timeStr = `${pad(hours)}:${pad(now.getMinutes())}:${pad(now.getSeconds())} ${ampm}`;
+  const el = document.getElementById('current-time');
+  if (window.matchMedia('(max-width: 700px)').matches) {
+    el.innerHTML = `${dayStr}<br>${timeStr}`;
+  } else {
+    el.textContent = `${dayStr} ${timeStr}`;
+  }
 }
 updateTime();
   setInterval(updateTime, 1000);


### PR DESCRIPTION
## Summary
- split clock into day and time on narrow screens

## Testing
- `python -m compileall app`

------
https://chatgpt.com/codex/tasks/task_e_685cd38d14b88321b7b38fcd43ed5245