### PR TITLE
Improve play buttons

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -138,6 +138,8 @@
     };
   };
 
+  const durations = {};
+
   async function loadAudio() {
     const res = await fetch('/api/audio');
     const data = await res.json();
@@ -146,6 +148,12 @@
     data.forEach(file => {
       const div = document.createElement('div');
       div.className = 'audio-item';
+
+      const audio = new Audio('/audio/' + encodeURIComponent(file.file));
+      audio.preload = 'metadata';
+      audio.onloadedmetadata = () => {
+        durations[file.file] = audio.duration;
+      };
 
       const name = document.createElement('div');
       name.className = 'audio-name';
@@ -172,7 +180,12 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ sound_file: file.file })
           });
-        } finally {
+          const delay = Math.max((durations[file.file] || 1) * 1000, 500);
+          setTimeout(() => {
+            testBtn.innerHTML = original;
+            testBtn.disabled = false;
+          }, delay);
+        } catch (e) {
           testBtn.innerHTML = original;
           testBtn.disabled = false;
         }

--- a/static/index.html
+++ b/static/index.html
@@ -38,6 +38,7 @@
   <script>
 let audioFiles = [];
 let audioMap = {};
+const durations = {};
 
 function formatTime12h(str) {
   const parts = str.split(':');
@@ -103,7 +104,12 @@ async function loadButtons() {
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ sound_file: btn.sound_file })
           });
-        } finally {
+          const d = Math.max((durations[btn.sound_file] || 1) * 1000, 500);
+          setTimeout(() => {
+            b.innerHTML = b.dataset.original;
+            b.disabled = false;
+          }, d);
+        } catch (e) {
           b.innerHTML = b.dataset.original;
           b.disabled = false;
         }
@@ -199,7 +205,12 @@ async function loadAudio() {
   const res = await fetch('/api/audio');
   audioFiles = await res.json();
   audioMap = {};
-  audioFiles.forEach(f => { audioMap[f.file] = f.name; });
+  audioFiles.forEach(f => {
+    audioMap[f.file] = f.name;
+    const a = new Audio('/audio/' + encodeURIComponent(f.file));
+    a.preload = 'metadata';
+    a.onloadedmetadata = () => { durations[f.file] = a.duration; };
+  });
 }
 document.getElementById('set-schedule').onclick = async () => {
   const name = document.getElementById('schedule-select').value;


### PR DESCRIPTION
## Summary
- maintain sound durations in admin page
- keep admin play button active until sound finishes
- load durations and keep quick buttons active

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685cdcb2c6b8832182ccb47ca150e711