### PR TITLE
Show registered license holder

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -237,6 +237,7 @@ def check_license(email: str, key: str) -> Dict[str, str]:
         return {
             "status": data.get("status", "INVALID"),
             "expires": data.get("expires", ""),
+            "name": data.get("name", ""),
         }
     except Exception as e:
         print("License check failed:", e)
@@ -571,6 +572,7 @@ def register_license(body: LicenseBody):
             "email": body.email,
             "key": body.key,
             "expires": result.get("expires", ""),
+            "name": result.get("name", ""),
             "status": "VALID",
         })
     return result

--- a/static/admin.html
+++ b/static/admin.html
@@ -265,7 +265,8 @@
       const statusEl = document.getElementById('license-status');
       const form = document.getElementById('license-form');
       if (data.status === 'VALID') {
-        statusEl.textContent = `Licensed through ${data.expires}`;
+        const name = data.name ? `Registered to: ${data.name} \u2013 ` : '';
+        statusEl.textContent = `${name}Licensed through ${data.expires}`;
         statusEl.classList.remove('unlicensed');
         form.style.display = 'none';
       } else {


### PR DESCRIPTION
## Summary
- include license holder name in server responses
- display `Registered to` name on settings page

## Testing
- `python -m py_compile app/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6869ded5c78c832180c9e01242a5e553